### PR TITLE
Avoid accidentally stripping authorization header for valid hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   (@chuckwondo)
 - Fix undesirable pre-commit changes when running on Windows
   ([#1143](https://github.com/nsidc/earthaccess/issues/1143)) (@ana-sher)
+- No longer erroneously strip authorization header for valid hosts
+  ([#1130](https://github.com/nsidc/earthaccess/issues/1130)) (@chuckwondo)
 
 ## [0.15.1] - 2025-09-16
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -24,7 +24,7 @@ from typing_extensions import deprecated
 
 import earthaccess
 
-from .auth import Auth, SessionWithHeaderRedirection
+from .auth import Auth
 from .daac import DAAC_TEST_URLS, find_provider
 from .results import DataGranule
 from .search import DataCollections
@@ -265,9 +265,6 @@ class Store(object):
             url: used to test the credentials and populate the class auth cookies
             method: HTTP method to test, default: "GET"
             bearer_token: if true, will be used for authenticated queries on CMR
-
-        Returns:
-            fsspec HTTPFileSystem (aiohttp client session)
         """
         if not hasattr(self, "_http_session"):
             self._http_session = self.auth.get_session(bearer_token)
@@ -394,7 +391,7 @@ class Store(object):
         session = fsspec.filesystem("https", client_kwargs=client_kwargs)
         return session
 
-    def get_requests_session(self) -> SessionWithHeaderRedirection:
+    def get_requests_session(self) -> requests.Session:
         """Returns a requests HTTPS session with bearer tokens that are used by CMR.
 
         This HTTPS session can be used to download granules if we want to use a direct,
@@ -802,7 +799,7 @@ class Store(object):
             )
 
     def _clone_session_in_local_thread(
-        self, original_session: SessionWithHeaderRedirection
+        self, original_session: requests.Session
     ) -> None:
         """Clone the original session and store it in the local thread context.
 
@@ -816,7 +813,7 @@ class Store(object):
             None
         """
         if not hasattr(self.thread_locals, "local_thread_session"):
-            local_thread_session = SessionWithHeaderRedirection()
+            local_thread_session = self.auth.get_session()  # type: ignore
             local_thread_session.headers.update(original_session.headers)
             local_thread_session.cookies.update(original_session.cookies)
             local_thread_session.auth = original_session.auth

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -36,14 +36,14 @@ class TestCreateAuth(unittest.TestCase):
 
         # Test
         auth = Auth()
-        session = auth.get_session()
-        headers = session.headers
         self.assertEqual(auth.authenticated, False)
         auth.login(strategy="interactive")
         self.assertEqual(auth.authenticated, True)
         self.assertEqual(auth.token, json_response)
 
         # test that we are creating a session with the proper headers
+        session = auth.get_session()
+        headers = session.headers
         self.assertTrue("User-Agent" in headers)
         self.assertTrue("earthaccess" in headers["User-Agent"])
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -159,9 +159,10 @@ class TestStoreSessions(unittest.TestCase):
                         responses.GET, url, body=f"Content of file {i + 1}", status=200
                     )
 
+                edl_hostname = "urs.earthdata.nasa.gov"
                 mock_auth = MagicMock()
                 mock_auth.authenticated = True
-                mock_auth.system.edl_hostname = "urs.earthdata.nasa.gov"
+                mock_auth.system.edl_hostname = edl_hostname
                 responses.add(
                     responses.GET,
                     "https://urs.earthdata.nasa.gov/profile",
@@ -169,7 +170,7 @@ class TestStoreSessions(unittest.TestCase):
                     status=200,
                 )
 
-                original_session = SessionWithHeaderRedirection()
+                original_session = SessionWithHeaderRedirection(edl_hostname)
                 original_session.cookies.set("sessionid", "mocked-session-cookie")
                 mock_auth.get_session.return_value = original_session
 
@@ -182,7 +183,7 @@ class TestStoreSessions(unittest.TestCase):
                 def mock_clone_session_in_local_thread(original_session):
                     """Mock session cloning to track cloned sessions."""
                     if not hasattr(store.thread_locals, "local_thread_session"):
-                        session = SessionWithHeaderRedirection()
+                        session = SessionWithHeaderRedirection(edl_hostname)
                         session.cookies.update(original_session.cookies)
                         cloned_sessions.add(id(session))
                         store.thread_locals.local_thread_session = session


### PR DESCRIPTION
Due to using a hardcoded list of "valid" hosts, when attempting to download data from valid hosts not in the hardcoded list, the authorization header was stripped, thus preventing download due to auth errors.

This fix removes the hardcoded list and securely handles applying basic auth to session objects.

Fixes #1130

<!--
Replace this text, including the symbols above and below it, with descriptive text about
the change you are proposing. Please include a reference to any issues addressed or
resolved in that text, for example "resolves #1".
-->

<!--
IMPORTANT: As a contributor, we would like as much help as you can offer, but we only
expect you to complete the steps in the "PR draft checklist" below. Maintainers are
willing and ready to help pick it up from there!

Please start by opening this Pull Request as a "draft". You can do this by
clicking the arrow on the right side of the green "Create pull request" button. While
your pull request is in "draft" state, maintainers will assume the PR isn't ready for
their attention unless they are specifically summoned using GitHub's @ system.

Follow the draft checklist below to move the PR out of draft state. If you accidentally
created the PR as a non-draft, don't worry, you can still change it to a draft using the
"Convert to draft" button on  the right side panel under the "Reviewers" section.
-->

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [x] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [x] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [ ] Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any. Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [ ] Add unit tests for any new features.
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1165.org.readthedocs.build/en/1165/

<!-- readthedocs-preview earthaccess end -->