### PR TITLE
Mention the PR template in PR docs

### DIFF
--- a/docs/contributing/pr-guide.md
+++ b/docs/contributing/pr-guide.md
@@ -6,6 +6,10 @@ However, our maintainers are mostly volunteers.
 In order to make the best use of their limited time, we ask that you follow this guide
 when opening a PR.
 
+When you open a PR, the description field will be auto-populated with some reminders and
+checklists to that effect.
+Please read them carefully!
+
 
 ## Checklist
 


### PR DESCRIPTION
## Description

Suggested here: https://github.com/nsidc/earthaccess/pull/1210#discussion_r2813775082

---

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1218.org.readthedocs.build/en/1218/

<!-- readthedocs-preview earthaccess end -->