### PR TITLE
Remove TestParam warning

### DIFF
--- a/tests/integration/param.py
+++ b/tests/integration/param.py
@@ -1,7 +1,7 @@
 from typing import TypedDict
 
 
-class TestParam(TypedDict):
+class ProviderParam(TypedDict):
     provider_name: str
 
     # How many of the top collections we will test, e.g. top 3 collections

--- a/tests/integration/test_cloud_download.py
+++ b/tests/integration/test_cloud_download.py
@@ -6,13 +6,13 @@ import earthaccess
 import pytest
 from earthaccess import Auth, DataGranules, Store
 
-from .param import TestParam
+from .param import ProviderParam
 from .sample import get_sample_granules, top_collections_for_provider
 
 logger = logging.getLogger(__name__)
 
 
-daac_list: list[TestParam] = [
+daac_list: list[ProviderParam] = [
     {
         "provider_name": "NSIDC_CPRD",
         "n_for_top_collections": 3,

--- a/tests/integration/test_cloud_open.py
+++ b/tests/integration/test_cloud_open.py
@@ -5,13 +5,13 @@ import magic
 import pytest
 from earthaccess import Auth, DataGranules, Store
 
-from .param import TestParam
+from .param import ProviderParam
 from .sample import get_sample_granules, top_collections_for_provider
 
 logger = logging.getLogger(__name__)
 
 
-daacs_list: list[TestParam] = [
+daacs_list: list[ProviderParam] = [
     {
         "provider_name": "NSIDC_CPRD",
         "n_for_top_collections": 2,


### PR DESCRIPTION

## Description

Running `nox -s integration-tests` produces warning that has to be explicitly ignored (at least for Windows platform) to run the integration tests (`nox -s integration-tests -- -W ignore::pytest.PytestCollectionWarning`), getting otherwise:
```
nox > Command pytest tests/integration -rxXs failed with exit code 2
nox > Session integration-tests failed.
```
Without tests being executed.

Closes #1145

---

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1227.org.readthedocs.build/en/1227/

<!-- readthedocs-preview earthaccess end -->