### PR TITLE
Remove redundant information from document title

### DIFF
--- a/docs/governance/decisions/929-move-repository.md
+++ b/docs/governance/decisions/929-move-repository.md
@@ -1,4 +1,4 @@
-# Decision Record: [#929 Move or fork to independent organization](https://github.com/earthaccess-dev/earthaccess/issues/929)
+# [#929](https://github.com/nsidc/earthaccess/issues/929) Move or fork to independent organization
 
 - Status: Accepted  <!-- optional -->
 - Deciders: @jhkennedy, @chuckwondo, @mfisher87, @Sherwin-14, @asteiker, @itcarroll, @danielfromearth, @JessicaS11


### PR DESCRIPTION
## Description

This doc shows up at Governance > Decisions > Decision record: ...etc...

This removes "Decision record" from the doc title for consistency with our other decision record doc, and to make it less redundant with its location. This information is present in the breadcrumbs (#1222).


---

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1233.org.readthedocs.build/en/1233/

<!-- readthedocs-preview earthaccess end -->