### PR TITLE
Rename Hackdays to Collaboration Cafes in workflow to create share-out discussions

### DIFF
--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -1,4 +1,4 @@
-name: Generate Discussion Thread for Hackdays
+name: Generate Discussion Thread for Collaboration Cafes
 
 on:
   workflow_dispatch:
@@ -12,14 +12,14 @@ jobs:
 
     steps:
 
-      - name: Generate the Hackathon title
+      - name: Generate the Collaboration Cafe title
         run: |
           DATE=$(date --iso-8601 | sed 's|-|/|g')
-          echo "DISCUSSION_TITLE=Hackathon $DATE" >> $GITHUB_ENV
+          echo "DISCUSSION_TITLE=Collaboration Cafe $DATE" >> $GITHUB_ENV
 
-      - name: Set the Hackathon description
+      - name: Set the Collaboration Cafe description
         run: |
-          echo "DISCUSSION_BODY=Reporting out on earthaccess hack days. Use the 'comment' button at the very bottom to send a message. Additionally, consider sending issues and PRs relevant to your work to help make the job of future readers easier. It is okay to duplicate information here! Use the reply feature to have a discussion under any comment. Enjoy!" >> $GITHUB_ENV
+          echo "DISCUSSION_BODY=Reporting out on earthaccess Collaboration Cafes. Use the 'comment' button at the very bottom to send a message. Additionally, consider sending issues and PRs relevant to your work to help make the job of future readers easier. It is okay to duplicate information here! Use the reply feature to have a discussion under any comment. Enjoy!" >> $GITHUB_ENV
 
       - name: Create Discussions
         env:


### PR DESCRIPTION
## Description

Replace "Hackday" and "Hackathon" language with "Collaboration Cafe" to make our biweekly community calls more inviting and inclusive.

Ref: #576

---

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] ~If needed, `CHANGELOG.md` updated~
- [x] ~If needed, docs and/or `README.md` updated~
- [x] ~If needed, unit tests added~
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1240.org.readthedocs.build/en/1240/

<!-- readthedocs-preview earthaccess end -->