### PR TITLE
Attempt to fix binder PR comment action

### DIFF
--- a/.github/workflows/binder-badge.yml
+++ b/.github/workflows/binder-badge.yml
@@ -5,6 +5,10 @@ on:
 jobs:
   badge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: manics/action-binderbadge@v3.0.0
         with:


### PR DESCRIPTION
<!--
IMPORTANT: Please open your PR in draft mode. Only mark it "Ready for review" after
completing the "Ready for review" checklist.

If you read the guide and your question isn't answered, please ping `@nsidc/earthaccess-support` in a comment!
--->

## Description

Related: https://github.com/manics/action-binderbadge/issues/680

---

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1242.org.readthedocs.build/en/1242/

<!-- readthedocs-preview earthaccess end -->