### PR TITLE
add a ".binder" folder to support mybinder.org and repo2docker builds

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,10 +2,8 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  # This environment bootstraps pip, the actual dev environment
-  # is installed and managed with pip
   - python==3.11
-  - pip
+  - pip>=25.1
 variables:
   # Allow pip installs when conda environment is active
   PIP_REQUIRE_VENV: 0

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -eux
-python -m pip install --editable ".[dev,test,docs]"
+pip install --group dev --group test --group docs --editable .


### PR DESCRIPTION
## Description

I don't know for how long #1244 has been a problem, but I don't see how the current repository worked with repo2docker and thus with mybinder.org. The docker builds would find the "environment.yml" file, but would not have the source tree and could not use `pip install -e`.

This PR adds a .binder folder that includes
1. a "environment.yml" file to constrain the python version. Unfortunately, a minimum version is not recognized by repo2docker, only an explicit version.
2. a "postBuild" to install the package with pip as advised in jupyterhub/repo2docker#1265

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
~~- [ ] If needed, `CHANGELOG.md` updated~~
~~- [ ] If needed, docs and/or `README.md` updated~~
~~- [ ] If needed, unit tests added~~
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [x] At least one approval
