### PR TITLE
Reduce pre-commit autoupdate frequency to quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autoupdate_schedule: "monthly" # Like dependabot
+  autoupdate_schedule: "quarterly"
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_prs: false # Comment "pre-commit.ci autofix" on a PR to trigger
 


### PR DESCRIPTION

## Description

Reduce a bit of maintenance burden. These updates aren't urgent. Dependabot will still run monthly.


---

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1247.org.readthedocs.build/en/1247/

<!-- readthedocs-preview earthaccess end -->