### PR TITLE
Update last updated date in 929-move-repository.md

### DIFF
--- a/docs/governance/decisions/929-move-repository.md
+++ b/docs/governance/decisions/929-move-repository.md
@@ -2,7 +2,7 @@
 
 - Status: Accepted  <!-- optional -->
 - Deciders: @jhkennedy, @chuckwondo, @mfisher87, @Sherwin-14, @asteiker, @itcarroll, @danielfromearth, @JessicaS11
-- Last updated: 2025-02-09
+- Last updated: 2026-02-16
 <!-- - Tags: [space and/or comma separated list of tags] optional -->
 
 Technical Story: [#929 Move or fork to independent organization](https://github.com/earthaccess-dev/earthaccess/issues/929)


### PR DESCRIPTION
## Description

The last updated date in the decision record was still dated from 2025. I just updated to reflect the merge date on Feb 16th of this year.


---

#### "Ready for review" checklist

- [ ] Open PR as draft
- [ x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x ] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x ] PR title is descriptive
- [ x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [ ] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1248.org.readthedocs.build/en/1248/

<!-- readthedocs-preview earthaccess end -->