### PR TITLE
Switch from PyPI token auth to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
     name: Publish to PyPI
     needs: ["build"]
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/p/earthaccess
     permissions:
       id-token: write
     steps:
@@ -29,8 +31,3 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        # NOTE: This is not the current best practice. Instead, we should use
-        # "trusted publishing":
-        # https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Description

Resolves #1243 

Trusted publishing is the current best practice using short-lived tokens to authenticate with PyPI. It's done by registering this repo and the `publish.yml` workflow as a trusted source in the settings for this package in the PyPI GUI. This is already done! Then when a publish happens, PyPI gets information from GitHub that confirms that the package is being published by the expected repo and Action, and then all the auth stuff happens automatically under the hood. Critically, **we store no secrets!**

https://docs.pypi.org/trusted-publishers/

TODO: Remove token from GitHub secrets


---

#### "Ready for review" checklist

- [x] Open PR as draft
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributing/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1251.org.readthedocs.build/en/1251/

<!-- readthedocs-preview earthaccess end -->