### PR TITLE
Add .env file support for environment login strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- Added .env file support for environment login strategy.
+  ([#748](https://github.com/earthaccess-dev/earthaccess/issues/748)) (@Sherwin-14)
+
 - Added `force` kwarg to `download()` to force redownloads.
 
 ## [v0.16.0] - 2026-01-30

--- a/docs/user/howto/authenticate.md
+++ b/docs/user/howto/authenticate.md
@@ -24,8 +24,8 @@ auth = earthaccess.login(strategy="netrc")
 ```
 
 If your Earthdata Login credentials are set as the environment variables
-`EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD`, you can explicitly specify their
-use:
+`EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD`, either in a `.env` file
+or your local environment, you can explicitly specify their use:
 
 ```py
 auth = earthaccess.login(strategy="environment")

--- a/docs/user/quick-start.md
+++ b/docs/user/quick-start.md
@@ -61,8 +61,7 @@ The following steps can be executed in a Python interpreter, a Python file, or a
 
 To access NASA data, you have to login using your Earth Data Login credentials.  You can register for a free Earth Data Login account [here](https://urs.earthdata.nasa.gov/).
 
-By default, `earthaccess` will look for your Earth Data Login credentials in a `.netrc` file, or in environment variables `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD`.  If you don't
-have either of these set up, you can login manually.  See [Authenticating](howto/authenticate.md) to learn how to create a `.netrc` file or environment variables.
+By default, `earthaccess` will look for your Earth Data Login credentials in a `.netrc` file, or as environment variables `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` (which can also be specified in a `.env` file).  If you don't have either of these set up, you can login manually.  See [Authenticating](howto/authenticate.md) to learn how to create a `.netrc` file or environment variables.
 
 ```python
 import earthaccess

--- a/earthaccess/__init__.py
+++ b/earthaccess/__init__.py
@@ -3,6 +3,8 @@ import threading
 from importlib.metadata import version
 from typing import Optional
 
+from dotenv import load_dotenv
+
 from .api import (
     auth_environ,
     collection_query,
@@ -30,6 +32,8 @@ from .store import Store
 from .system import PROD, UAT
 
 logger = logging.getLogger(__name__)
+
+load_dotenv()
 
 __all__ = [
     # api.py

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -119,10 +119,10 @@ class Auth(object):
                 * **"interactive"**: Enter a username and password.
                 * **"netrc"**: (default) Retrieve a username and password from ~/.netrc.
                 * **"environment"**:
-                    Retrieve either a username and password pair from the
-                    `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables,
-                    or an Earthdata login token from the `EARTHDATA_TOKEN` environment
-                    variable.
+                    Retrieve credentials from a `.env` file or environment variables.
+                    Reads either a username and password pair
+                    `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD`, or an Earthdata
+                    login token from `EARTHDATA_TOKEN`.
             persist: Will persist username and password credentials in a `.netrc` file.
             system: the EDL endpoint to log in to Earthdata, defaults to PROD
 
@@ -289,8 +289,8 @@ class Auth(object):
         if (not username or not password) and not token:
             raise LoginStrategyUnavailable(
                 "Either the environment variables EARTHDATA_USERNAME and "
-                "EARTHDATA_PASSWORD must both be set, or EARTHDATA_TOKEN must be set for "
-                "the 'environment' login strategy."
+                "EARTHDATA_PASSWORD must both be set, or EARTHDATA_TOKEN must be set. "
+                "Credentials can be set in a `.env` file."
             )
 
         logger.debug("Using environment variables for EDL")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "multimethod >=1.8",
   "importlib-resources >=6.3.2",
   "typing_extensions >=4.10.0",
+  "python-dotenv>=1.1.1",
 ]
 
 [project.urls]

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 import responses
 from earthaccess import Auth
-from earthaccess.exceptions import LoginAttemptFailure
+from earthaccess.exceptions import LoginAttemptFailure, LoginStrategyUnavailable
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +85,29 @@ class TestCreateAuth(unittest.TestCase):
         auth.login(strategy="environment")
         self.assertEqual(auth.authenticated, True)
         self.assertEqual(auth.token, json_response)
+
+    @responses.activate
+    @mock.patch.dict(
+        os.environ, {"EARTHDATA_USERNAME": "user", "EARTHDATA_PASSWORD": "password"}
+    )
+    def test_auth_environment_with_username_password(self):
+        json_response = {"access_token": "EDL-token-1", "expiration_date": "12/15/2021"}
+        responses.add(
+            responses.POST,
+            "https://urs.earthdata.nasa.gov/api/users/find_or_create_token",
+            json=json_response,
+            status=200,
+        )
+        auth = Auth()
+        auth.login(strategy="environment")
+        self.assertEqual(auth.authenticated, True)
+        self.assertEqual(auth.token, json_response)
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_auth_environment_missing_credentials(self):
+        auth = Auth()
+        with pytest.raises(LoginStrategyUnavailable):
+            auth.login(strategy="environment")
 
     @responses.activate
     @mock.patch("getpass.getpass")


### PR DESCRIPTION
This PR allows the `environment` login strategy to load environment variables from `.env` file.  Resolves #748.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1265.org.readthedocs.build/en/1265/

<!-- readthedocs-preview earthaccess end -->