### PR TITLE
Enabled UP (pyupgrade) ruleset and fix violations

### DIFF
--- a/earthaccess/virtual/_types.py
+++ b/earthaccess/virtual/_types.py
@@ -7,16 +7,16 @@ from typing import Any, Literal, Union
 # parser instance.  The strings are the exact class names exported from
 # ``virtualizarr.parsers`` so that callers can pass them directly without
 # importing VirtualiZarr themselves.
-ParserType = Union[
+ParserType = (
     Literal[
         "DMRPPParser",
         "HDFParser",
         "NetCDF3Parser",
         "KerchunkJSONParser",
         "KerchunkParquetParser",
-    ],
-    Any,
-]
+    ]
+    | Any
+)
 
 AccessType = Literal["direct", "indirect"]
 ParallelType = Literal["dask", "lithops", False]
@@ -33,10 +33,10 @@ CompatType = Literal[
 ]
 
 # Mirrors xarray.core.types.CombineAttrsOptions
-CombineAttrsType = Union[
-    Literal["drop", "identical", "no_conflicts", "drop_conflicts", "override"],
-    Callable[..., Any],
-]
+CombineAttrsType = (
+    Literal["drop", "identical", "no_conflicts", "drop_conflicts", "override"]
+    | Callable[..., Any]
+)
 
 # Mirrors the data_vars parameter of xarray.combine_nested / open_mfdataset
-DataVarsType = Union[Literal["all", "minimal", "different"], list[str]]
+DataVarsType = Literal["all", "minimal", "different"] | list[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,17 +291,7 @@ ignore = [
   "TD004",
   "TRY002",
   "TRY003",
-  "TRY400",
-  "UP004",
-  "UP006",
-  "UP007",
-  "UP015",
-  "UP024",
-  "UP032",
-  "UP034",
-  "UP035",
-  "UP036",
-  "UP045",
+  "TRY400"
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,7 +291,7 @@ ignore = [
   "TD004",
   "TRY002",
   "TRY003",
-  "TRY400"
+  "TRY400",
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
Fixed errors based on UP rulesets. As suggested in the [issue](https://github.com/earthaccess-dev/earthaccess/issues/383) description.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1290.org.readthedocs.build/en/1290/

<!-- readthedocs-preview earthaccess end -->