### PR TITLE
ci(dependabot): scan composite action in .github/actions/install-pkg

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,16 @@ updates:
           - "*"
     cooldown:
       default-days: 14
+  # Dependabot's github-actions ecosystem does not recurse into composite
+  # actions under .github/actions/, so each custom action needs its own entry
+  # for the `uses:` references inside action.yml to receive updates.
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/install-pkg"
+    schedule:
+      interval: "monthly"
+    groups:
+      gha-dependencies:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
## Summary

Dependabot's `github-actions` ecosystem does not recurse into composite actions, so the `uses:` references inside `.github/actions/install-pkg/action.yml` were never scanned (`setup-uv` is currently 3 major versions behind). Add a second `github-actions` entry scoped to that action's directory, reusing the existing schedule, grouping, and cooldown so updates land together.

## Test plan

- [ ] After merge, verify dependabot opens an update PR for `.github/actions/install-pkg/action.yml` (e.g. bumping `setup-uv` to the current major version).

Fixes #1300
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1302.org.readthedocs.build/en/1302/

<!-- readthedocs-preview earthaccess end -->