### PR TITLE
Enabled TRY (error handling) rulesets and fixed violations

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -62,7 +62,7 @@ def status(system: System = PROD, raise_on_outage: bool = False) -> dict[str, st
             if service := next(filter(name.startswith, services), None):
                 statuses[service] = entry.get("status", "Unknown")
     except (json.JSONDecodeError, requests.exceptions.RequestException):
-        logger.error(msg)
+        logger.exception(msg)
 
     if raise_on_outage and any(
         status not in {"OK", "Unknown"} for status in statuses.values()
@@ -435,9 +435,9 @@ def download(
             pqdm_kwargs=pqdm_kwargs,
             force=force,
         )
-    except AttributeError as err:
-        logger.error(
-            f"{err}: You must call earthaccess.login() before you can download data",
+    except AttributeError:
+        logger.exception(
+            "You must call earthaccess.login() before you can download data",
         )
 
     return []

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -212,10 +212,10 @@ class Auth:
             if r:
                 return r.json()
 
-            logger.error(
+            logger.exception(
                 f"Authentication with Earthdata Login failed with:\n{r.text[:1000]}",
             )
-            logger.error(
+            logger.exception(
                 f"Consider accepting the EULAs available at {self._eula_url} and applications at {self._apps_url}",
             )
 
@@ -317,7 +317,7 @@ class Auth:
 
             if not (token_resp.ok):  # type: ignore
                 msg = f"Authentication with Earthdata Login failed with:\n{token_resp.text}"
-                logger.error(msg)
+                logger.exception(msg)
                 raise LoginAttemptFailure(msg)
 
             logger.info("You're now authenticated with NASA Earthdata Login")
@@ -346,8 +346,8 @@ class Auth:
         try:
             netrc_loc.touch(exist_ok=True)
             netrc_loc.chmod(0o600)
-        except Exception as e:
-            logger.error(e)
+        except Exception:
+            logger.exception("")
             return False
 
         my_netrc = Netrc(str(netrc_loc))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,6 @@ ignore = [
   "PERF401",
   "PERF403",
   "PGH003",
-  "PIE790",
   "PLC0415",
   "PLR0913",
   "PLR1704",
@@ -284,9 +283,7 @@ ignore = [
   "TD002",
   "TD003",
   "TD004",
-  "TRY002",
   "TRY003",
-  "TRY400",
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -53,8 +53,8 @@ def test_auth_can_fetch_s3_credentials(daac):
 
     try:
         credentials = earthaccess.get_s3_credentials(daac["short-name"])
-    except requests.RequestException as e:
-        logger.error(f"Failed to fetch S3 credentials: {e}")
+    except requests.RequestException:
+        logger.exception("Failed to fetch S3 credentials")
     else:
         assert isinstance(credentials, dict)
         assert "accessKeyId" in credentials

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -395,7 +395,7 @@ def test_sibling_tempfile_error(tmp_path):
     with pytest.raises(Exception, match="Some error to trigger cleanup"):
         with _sibling_tempfile(trg_file) as temp_file:
             temp_file.write_text(new_text)
-            raise Exception("Some error to trigger cleanup")
+            raise RuntimeError("Some error to trigger cleanup")
     assert not temp_file.exists()
     assert trg_file.exists()
     assert trg_file.read_text() == orig_text


### PR DESCRIPTION
Fixed errors based on other TRY rulesets barring "TRY003" as that involves making explicit exception classes.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1306.org.readthedocs.build/en/1306/

<!-- readthedocs-preview earthaccess end -->