### PR TITLE
Updates to triaging guide: Issue prioritization and high-level triage workflow

### DIFF
--- a/docs/contributor/pr-guide.md
+++ b/docs/contributor/pr-guide.md
@@ -30,7 +30,7 @@ If you forget this step, you can "convert to draft" towards the top of the right
 panel.
 
 
-### Review [contributing documentation](/contributor/index.md)
+### Review [contributing documentation](./index.md)
 
 If you're new to our community, please ensure you're aware of how we organize
 contributions.

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -17,12 +17,25 @@ With constant influx of new issues, it's essential to prioritize and categorize 
 3. Issues are reviewed and groomed using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1)
 4. An issue is worked following the [Pull Request (PR) Guiide](./pr-guide.md).
    * The issue is self-assigned and moved to an `In Progress` status.
-5. 
-
+   * The issue is linked to the related PR, and closed after the PR is merged.
 
 Details on each of these workflow steps are provided below. 
 
 ## Issue Prioritization
+TODO
+
+Definitions of priority labels for docs:
+Critical:
+If it’s broken
+Would a user see this and immediately stop using the docs
+Important:
+Does it impact primary user workflows but not necessarily broken
+Nice to have: 
+Sprinkles and confetti 
+Contributoring docs lower priority than end-users
+Depends on doc sections:
+User guide: main audience is the end user
+https://earthaccess.readthedocs.io/en/latest/contributor/ vs https://earthaccess.readthedocs.io/en/latest/user/, https://earthaccess.readthedocs.io/en/latest/api/ (contributor is also the user), and Overview (https://earthaccess.readthedocs.io/en/latest/) 
 
 ## Labeling Issues
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -1,6 +1,8 @@
-# Triaging guide
+# Issue Triaging and Prioritization Guide
 
-With constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized and up-to-date issue tracker.
+With constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+
+We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for both new and veteran contributors: "I'm interested in working on important issues that will fix or improve `earthaccess`. Where do I begin?"
 
 ## Labeling Issues
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -2,7 +2,9 @@
 
 With constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 
-We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for both new and veteran contributors: "I'm interested in working on important issues that will fix or improve `earthaccess`. Where do I begin?"
+!!! tip
+
+    We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for new and veteran contributors alike: "I'm interested in working on important issues that will fix or improve `earthaccess`. Where do I begin?"
 
 ## Labeling Issues
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -21,9 +21,11 @@ With a constant influx of new issues, it's essential to prioritize and categoriz
 
 Details on each of these workflow steps are provided below. 
 
+
 ## Moving an issue to Backlog status
 
 This section will cover the `earthaccess` project status, guidelines for when to use the "Close Issue as Not Planned" feature, and how to handle issues that are not planned or feasible.
+
 
 ### Project status
 
@@ -33,11 +35,10 @@ By default, all new issues are created without a project status. Issues without 
 - In Review
 - Done
 
-Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views.
+When triaging a new issue, review the information and provide a response or follow up with question(s) if needed. Providing gratitude for the submission as a text or emoji response is highly encouraged. Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. If you are unsure, add the **needs: triage** label. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views. 
 
-### Close Issue as Not Planned
 
-#### When to "Close as not planned"?
+### When to "Close as not planned"?
 
 Close issues as "not planned" when:
 
@@ -64,7 +65,7 @@ When labeling an issue, choose the label(s) that best describes the issue. Using
 - **type: decision record**: Use this label for issues and PR's that address a new decision record document (e.g. https://github.com/earthaccess-dev/earthaccess/pull/1047).   
 - **type: duplicate**: Use this label for issues that are duplicates of existing ones.
 - **type: enhancement**: Use this label for requests for new features or improvements to existing functionalities.
-- **type: experience report**: Use this label for issues that include the reporter's usability experience 
+- **type: experience report**: Use this label for issues that describe a firsthand usability experience. 
 - **type: metrics**: This label is automatically applied upon creation of the Monthly metrics issue. See the [Monthly issue metrics](https://github.com/earthaccess-dev/earthaccess/blob/main/.github/workflows/issue-metrics.yml) action for more details.  
 - **type: will not do**: Use this label for issues that won’t be addressed or fixed.
 
@@ -76,13 +77,17 @@ These labels describe what portion of the project they affect:
 - **impact: core**: Issues that affect the core Python codebase.
 - **impact: dependencies**: Use this label for issues concerning dependencies.
 - **impact: documentation**: Use this label for issues related to documentation.
-- **impact: automation**: Use this label for issues related to the CI/CD pipeline or automation
+- **impact: automation**: Use this label for issues related to the CI/CD pipeline or automation.
+- **impact: governance**: Issues that impact the project's governance or decision-making process.
+
+Impact labels are also used to help group related issues based on a particular feature or topic. For example, **impact: virtual-datasets** is used to categorize Issues or Discussions related to virtualizarr integration and support. These labels may evolve over time as new features are worked. 
 
 ### Needs labels
 
 - **needs: decision**: We're struggling to decide what to do and the decision committee needs to help.
 - **needs: feedback**:  Use this label for issues where feedback is requested from the team or our community.
 - **needs: help**: Use this label for issues where additional help or contributions are needed.
+- **needs: triage**: Use this label for new issues that require additional information to determine whether it should move to the backlog, or close as not planned. 
 
 ### Special labels
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -1,10 +1,8 @@
 # Issue Triaging and Prioritization Guide
 
-With a constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, and best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 
-!!! tip
-
-    We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for both new and experienced contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"
+**We hope that this guide will help empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
 
 ## Issue Lifecycle
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -148,6 +148,7 @@ The issue is a real improvement but not urgent.
 - Minor inconsistencies or style issues
 
 *Bug example:* Affects a small number of users, data collections, or edge-case workflows; a workaround is readily available or the impact is cosmetic.
+
 *Documentation example:* Minor inconsistencies, typos, or style issues; improvements to contributing or developer-facing docs with no impact on end-user workflows.
 
 ### Notes for Triagers

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -7,7 +7,7 @@ This document outlines our approach to triaging issues on GitHub, including guid
 ## Issue Lifecycle
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
-2. The issue is triaged in order to: 
+2. The issue is triaged by a community member in order to: 
    * Determine whether the issue should be pursued and moved to a Backlog status, or closed as not planned.
    * Add or adjust issue labels.
    * Add an issue prioritization. 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -115,7 +115,7 @@ https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 
 Issue priorities are surfaced within the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views. When triaging a new issue, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
 
-### Priority: `1- Critical`
+### Priority: `1 - Critical`
 
 The issue has significant, immediate impact on users and/or major components of the `earthaccess` library. 
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -124,6 +124,7 @@ The issue has significant, immediate impact on users and/or major components of 
 - Users are likely to stop using the library or lose trust in it
 
 *Bug example:* Users cannot search or access data for a significant number of collections or key `earthaccess` workflows.
+
 *Documentation example:* Content is incorrect or missing in a way that would immediately block or mislead a user.
 
 ### Priority: `2 - Important`

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -13,7 +13,7 @@ This document outlines our approach to triaging issues on GitHub, including guid
    * Add an issue prioritization. 
    * Respond and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
 3. Issues are reviewed and groomed using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1)
-4. An issue is worked following the [Pull Request (PR) Guiide](./pr-guide.md).
+4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
    * The issue is self-assigned and moved to an `In Progress` status.
    * The issue is linked to the related PR, and closed after the PR is merged.
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -1,34 +1,28 @@
-~~
-
-NOTES
-* General workflow:
-* - New issue entered
-  - Triager reviews issue. All new issues begin without a status. Ultimate goal is to decide whether to close as unplanned, or move to the backlog.
-      - Add labels
-      - Add priority
-      - Add to Backlog status. Priority is then reflected in the project view
-
-## Issue Labels
-This is a guide walking through the various labels...
-
-## Issue Priority
-
-## 
-
-~~
-
-
-
 # Issue Triaging and Prioritization Guide
 
 With constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 
 !!! tip
 
-    We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for new or experienced contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"
+    We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for both new and experienced contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"
+
+## Issue Lifecycle
+
+1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
+2. The issue is triaged in order to: 
+   * Determine whether the issue should be pursued and moved to a Backlog status, or closed as not planned.
+   * Add or adjust issue labels.
+   * Add an issue prioritization. 
+   * Respond and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
+3. Issues are reviewed and groomed using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1)
+4. An issue is worked following the [Pull Request (PR) Guiide](./pr-guide.md).
+   * The issue is self-assigned and moved to an `In Progress` status.
+5. 
 
 
+Details on each of these workflow steps are provided below. 
 
+## Issue Prioritization
 
 ## Labeling Issues
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -115,24 +115,77 @@ https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 
 ## Issue Prioritization
 
-TODO
+Issue priorities are surfaced within the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views. When triaging a new issue, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
 
-Definitions of priority labels for docs:
-**Critical:**
-- If it’s broken
-- Would a user see this and immediately stop using the docs
-**Important:**
-- Does it impact primary user workflows but not necessarily broken
-**Nice to have:** 
-- Sprinkles and confetti 
-- Contributoring docs lower priority than end-users
-- Depends on doc sections:
--- User guide: main audience is the end user
-https://earthaccess.readthedocs.io/en/latest/contributor/ vs https://earthaccess.readthedocs.io/en/latest/user/, https://earthaccess.readthedocs.io/en/latest/api/ (contributor is also the user), and Overview (https://earthaccess.readthedocs.io/en/latest/) 
+### Priority: `1- Critical`
+
+The issue has significant, immediate impact on users and/or major components of the `earthaccess` library. 
+
+- Core functionality is broken or inaccessible for a meaningful number of users
+- Key workflows or use cases are blocked
+- Users are likely to stop using the library or lose trust in it
+
+*Bug example:* Users cannot search or access data for a significant number of collections or key `earthaccess` workflows.
+*Documentation example:* Content is incorrect or missing in a way that would immediately block or mislead a user.
+
+### Priority: `2 - Important`
+
+The issue has real impact but is not immediately blocking a majority of users.
+
+- Affects primary user workflows but a workaround exists, or only a subset of users is affected
+- Incorrect or confusing content that degrades the experience without fully blocking users
+- Less common use cases or data collections are impacted
+
+*Bug example:* Functionality is degraded but users can still accomplish their goals.
+*Documentation example:* A Tutorial or secondary documentation is broken or unclear; contributing docs with significant usability issues.
+
+### Priority: `3 - Nice to have` 
+
+The issue is a real improvement but not urgent.
+
+- Affects a small percentage of users, data collections, or use cases
+- Polish, enhancements, or "nice to haves" with no meaningful workflow impact
+- Minor inconsistencies or style issues
+
+*Bug example:* Affects a small number of users, data collections, or edge-case workflows; a workaround is readily available or the impact is cosmetic.
+*Documentation example:* Minor inconsistencies, typos, or style issues; improvements to contributing or developer-facing docs with no impact on end-user workflows.
+
+### Notes for Triagers
+
+- **When in doubt, start at Medium** and adjust based on community feedback or additional context.
+- The [User Guide](https://earthaccess.readthedocs.io/en/stable/user/) and [API Reference](https://earthaccess.readthedocs.io/en/stable/api/) generally warrant higher priority than contributing or developer docs when impact is otherwise similar.
+- Priority reflects *impact and urgency*, not effort — a quick fix can still be High priority.
+
+## Issue Triaging Workflow
+
+``` mermaid
+
+flowchart TD
+  %%{init: {"flowchart": {"htmlLabels": false}} }%%
+  classDef default font-size:32pt;
+  start{"`Followed
+  issue
+  template?`"}
+  start ==NO==> close1[Request needed information from reporter and update issue on behalf of reporter]
+  start == YES ==> dupe{Is duplicate?}
+  dupe == YES ==> close2[Close and point to duplicate]
+  dupe == NO ==> repro{Has proper reproduction?}
+  repro == NO ==> close3[Label: 'needs reproduction' bot will auto close if no update has been made in 3 days]
+  repro == YES ==> real{Is actually a bug?}
+  real == NO ==> intended{Is the intended behaviour?}
+  intended == YES ==> explain[Explain and close point to docs if needed]
+  intended == NO ==> open[Keep open for discussion Remove 'pending triage' label]
+  real == YES ==> real2["Confirm that 'Bug' label was automatically added as part of the Bug Issue template, otherwise add 'Bug' label."]
+
+
+  %% Link Color %%
+    linkStyle default stroke:black,stroke-width:2px,font-size:24pt;
+
+```
 
 
 ## Discussions vs Issues
-TODO Move to https://earthaccess.readthedocs.io/en/latest/contributor/ 
+TODO Move to https://earthaccess.readthedocs.io/en/latest/contributor/ ?
 
 This section would cover the guidelines for when to use discussions versus issues, and how to migrate between them.
 
@@ -168,29 +221,4 @@ Migrate an issue to a discussion when:
 - The issue is a general question or topic.
 - The issue is not specific or actionable.
 
-## Issue Triaging Workflow
 
-``` mermaid
-
-flowchart TD
-  %%{init: {"flowchart": {"htmlLabels": false}} }%%
-  classDef default font-size:32pt;
-  start{"`Followed
-  issue
-  template?`"}
-  start ==NO==> close1[Request needed information from reporter and update issue on behalf of reporter]
-  start == YES ==> dupe{Is duplicate?}
-  dupe == YES ==> close2[Close and point to duplicate]
-  dupe == NO ==> repro{Has proper reproduction?}
-  repro == NO ==> close3[Label: 'needs reproduction' bot will auto close if no update has been made in 3 days]
-  repro == YES ==> real{Is actually a bug?}
-  real == NO ==> intended{Is the intended behaviour?}
-  intended == YES ==> explain[Explain and close point to docs if needed]
-  intended == NO ==> open[Keep open for discussion Remove 'pending triage' label]
-  real == YES ==> real2["Confirm that 'Bug' label was automatically added as part of the Bug Issue template, otherwise add 'Bug' label."]
-
-
-  %% Link Color %%
-    linkStyle default stroke:black,stroke-width:2px,font-size:24pt;
-
-```

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -1,6 +1,6 @@
 # Issue Triaging and Prioritization Guide
 
-With constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+With a constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 
 !!! tip
 
@@ -21,21 +21,37 @@ With constant influx of new issues, it's essential to prioritize and categorize 
 
 Details on each of these workflow steps are provided below. 
 
-## Issue Prioritization
-TODO
+## Moving an issue to Backlog status
 
-Definitions of priority labels for docs:
-Critical:
-If it’s broken
-Would a user see this and immediately stop using the docs
-Important:
-Does it impact primary user workflows but not necessarily broken
-Nice to have: 
-Sprinkles and confetti 
-Contributoring docs lower priority than end-users
-Depends on doc sections:
-User guide: main audience is the end user
-https://earthaccess.readthedocs.io/en/latest/contributor/ vs https://earthaccess.readthedocs.io/en/latest/user/, https://earthaccess.readthedocs.io/en/latest/api/ (contributor is also the user), and Overview (https://earthaccess.readthedocs.io/en/latest/) 
+This section will cover the `earthaccess` project status, guidelines for when to use the "Close Issue as Not Planned" feature, and how to handle issues that are not planned or feasible.
+
+### Project status
+
+By default, all new issues are created without a project status. Issues without a status are listed in the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view. Statuses include:
+- Backlog
+- In Progress
+- In Review
+- Done
+
+Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views.
+
+### Close Issue as Not Planned
+
+#### When to "Close as not planned"?
+
+Close issues as "not planned" when:
+
+- An issue is not aligned with the project's goals or priorities.
+- An issue is not feasible to be addressed due to technical or resource constraints.
+- An issue is a duplicate of an existing issue that has already been addressed.
+
+When closing an issue as not planned, keep the following best practices in mind:
+
+- Provide a clear explanation as to why the issue is not planned or feasible.
+- Offer alternative solutions or workarounds, if possible.
+- Link to relevant documentation or resources, if applicable.
+- Add the **type: will not do** label.
+
 
 ## Labeling Issues
 
@@ -44,9 +60,12 @@ When labeling an issue, choose the label(s) that best describes the issue. Using
 
 ### Issue Types
 
-- **type: bug**: Use for issues that identify bugs causing incorrect or unexpected behavior.
+- **type: bug**: Use for issues that identify bugs causing incorrect or unexpected behavior. This label is applied automatically if the [Bug template](https://github.com/earthaccess-dev/earthaccess/issues/new?template=bug.yml) is used.
+- **type: decision record**: Use this label for issues and PR's that address a new decision record document (e.g. https://github.com/earthaccess-dev/earthaccess/pull/1047).   
 - **type: duplicate**: Use this label for issues that are duplicates of existing ones.
 - **type: enhancement**: Use this label for requests for new features or improvements to existing functionalities.
+- **type: experience report**: Use this label for issues that include the reporter's usability experience 
+- **type: metrics**: This label is automatically applied upon creation of the Monthly metrics issue. See the [Monthly issue metrics](https://github.com/earthaccess-dev/earthaccess/blob/main/.github/workflows/issue-metrics.yml) action for more details.  
 - **type: will not do**: Use this label for issues that won’t be addressed or fixed.
 
 ### Impact labels
@@ -89,26 +108,26 @@ For example, to link to the "good first issue" label in the earthaccess-dev/eart
 https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 ```
 
+## Issue Prioritization
 
-## Close Issue as Not Planned
+TODO
 
-This section will cover the guidelines for when to use the "Close Issue as Not Planned" feature, and how to handle issues that are not planned or feasible.
+Definitions of priority labels for docs:
+**Critical:**
+- If it’s broken
+- Would a user see this and immediately stop using the docs
+**Important:**
+- Does it impact primary user workflows but not necessarily broken
+**Nice to have:** 
+- Sprinkles and confetti 
+- Contributoring docs lower priority than end-users
+- Depends on doc sections:
+-- User guide: main audience is the end user
+https://earthaccess.readthedocs.io/en/latest/contributor/ vs https://earthaccess.readthedocs.io/en/latest/user/, https://earthaccess.readthedocs.io/en/latest/api/ (contributor is also the user), and Overview (https://earthaccess.readthedocs.io/en/latest/) 
 
-### When to "Close as not planned"?
-
-Close issues as "not planned" when:
-
-- An issue is not aligned with the project's goals or priorities.
-- An issue is not feasible to be addressed due to technical or resource constraints.
-- An issue is a duplicate of an existing issue that has already been addressed.
-
-When closing an issue as not planned, keep the following best practices in mind:
-
-- Provide a clear explanation as to why the issue is not planned or feasible.
-- Offer alternative solutions or workarounds, if possible.
-- Link to relevant documentation or resources, if applicable.
 
 ## Discussions vs Issues
+TODO Move to https://earthaccess.readthedocs.io/en/latest/contributor/ 
 
 This section would cover the guidelines for when to use discussions versus issues, and how to migrate between them.
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -1,10 +1,34 @@
+~~
+
+NOTES
+* General workflow:
+* - New issue entered
+  - Triager reviews issue. All new issues begin without a status. Ultimate goal is to decide whether to close as unplanned, or move to the backlog.
+      - Add labels
+      - Add priority
+      - Add to Backlog status. Priority is then reflected in the project view
+
+## Issue Labels
+This is a guide walking through the various labels...
+
+## Issue Priority
+
+## 
+
+~~
+
+
+
 # Issue Triaging and Prioritization Guide
 
 With constant influx of new issues, it's essential to prioritize and categorize them efficiently to ensure that the most important problems are addressed promptly. This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, as well as best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 
 !!! tip
 
-    We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for new and veteran contributors alike: "I'm interested in working on important issues that will fix or improve `earthaccess`. Where do I begin?"
+    We hope that this guide will help empower anyone to contribute to issue triaging, and ultimately address a common question for new or experienced contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"
+
+
+
 
 ## Labeling Issues
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -8,7 +8,7 @@ This document outlines our approach to triaging issues on GitHub, including guid
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
 2. The issue is triaged by a community member in order to: 
-   * Determine whether the issue should be pursued and moved to a Backlog status, or closed as not planned.
+   * Determine whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
    * Add or adjust issue labels.
    * Add an issue prioritization. 
    * Respond and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -135,6 +135,7 @@ The issue has real impact but is not immediately blocking a majority of users.
 - Less common use cases or data collections are impacted
 
 *Bug example:* Functionality is degraded but users can still accomplish their goals.
+
 *Documentation example:* A Tutorial or secondary documentation is broken or unclear; contributing docs with significant usability issues.
 
 ### Priority: `3 - Nice to have` 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -14,8 +14,10 @@ This document outlines our approach to triaging issues on GitHub, including guid
    * Respond and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
 3. Issues are reviewed and groomed using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1)
 4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
-   * The issue is self-assigned and moved to an `In Progress` status.
-   * The issue is linked to the related PR, and closed after the PR is merged.
+   * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
+   * Update status to `In Progress`.
+   * Link the issue to the related PR with a comment "Resolves #N" (`N` is the issue number). The issue will auto-close when the PR is merged.
+   * If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
 
 Details on each of these workflow steps are provided below. 
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -46,7 +46,7 @@ Close issues as "not planned" when:
 - An issue is not feasible to be addressed due to technical or resource constraints.
 - An issue is a duplicate of an existing issue that has already been addressed.
 
-When closing an issue as not planned, keep the following best practices in mind:
+When closing an issue as not planned:
 
 - Provide a clear explanation as to why the issue is not planned or feasible.
 - Offer alternative solutions or workarounds, if possible.

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -30,6 +30,7 @@ This section will cover the `earthaccess` project status, guidelines for when to
 ### Project status
 
 By default, all new issues are created without a project status. Issues without a status are listed in the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view. Statuses include:
+
 - Backlog
 - In Progress
 - In Review

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -24,7 +24,6 @@ Details on each of these workflow steps are provided below.
 
 ## Moving an issue to Backlog status
 
-This section will cover the `earthaccess` project status, guidelines for when to use the "Close Issue as Not Planned" feature, and how to handle issues that are not planned or feasible.
 
 
 ### Project status

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -1,8 +1,10 @@
 # Issue Triaging and Prioritization Guide
 
-This document outlines our approach to triaging issues in GitHub, including guidelines for labeling and resolving issues, and best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+This document outlines our approach to triaging issues in GitHub, including guidelines for labeling and resolving issues, and best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker. 
 
 **We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
+
+See {ref}`issue-grooming` below for details on how to prioritize `earthaccess` issues and browse these via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
 
 ## Issue Lifecycle
 
@@ -72,7 +74,10 @@ To link to a label in GitHub Markdown, copy-and-paste the URL to the label by ri
 https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 ```
 
+(issue-grooming)=
 ## The issue is groomed
+
+TODO: Under the groomed section, have more of an intro or sub section on prioritizing issues. Then we can introduce the project views and how they are used, thinking about the contributor audience in addition to triager.
 
 Issues are groomed periodically to organize and prioritize the backlog. Issue priorities are surfaced within the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views. When triaging a new issue, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -12,7 +12,7 @@ This document outlines our approach to triaging issues on GitHub, including guid
    * Add or adjust issue labels.
    * Add an issue prioritization. 
    * Respond and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
-3. Issues are reviewed and groomed using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1)
+3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
 4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
    * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
    * Update status to `In Progress`.

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -7,7 +7,7 @@ This document outlines our approach to triaging issues in GitHub, including guid
 See the [Issue grooming](#issue-grooming) section below for details on how to identify and browse prioritized issues via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
 
 
-## Issue Lifecycle
+## Issue lifecycle
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
 2. The issue is triaged to initially assess the reported issue and determine its priority.  

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -142,7 +142,7 @@ The issue is a real improvement but not urgent.
 - If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
 
 
-## Issue Triaging Workflow
+## Issue triaging workflow
 
 ``` mermaid
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -7,7 +7,17 @@ This document outlines our approach to triaging issues on GitHub, including guid
 ## Issue Lifecycle
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
-2. Issue triaging is led by the `earthaccess` community manager, though any community member is welcome and encouraged to contribute. Triaging involves:
+2. An issue is triaged to initially assess the reported issue and determine its priority.  
+3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
+
+Details on each of these workflow steps are provided below. 
+
+### A new issue is created
+
+### An issue is triaged
+
+Triaging is led by the `earthaccess` community manager, though any community member is welcome and encouraged to contribute. Triaging involves:
 
     * Determining whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
 
@@ -17,8 +27,9 @@ This document outlines our approach to triaging issues on GitHub, including guid
 
     * Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
 
-3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
-4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
+### An issue is groomed
+
+### An issue is worked as a new pull request
 
     * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
 
@@ -28,10 +39,10 @@ This document outlines our approach to triaging issues on GitHub, including guid
 
     * If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
 
-Details on each of these workflow steps are provided below. 
 
 
-## Moving an issue to Backlog status
+
+### Moving an issue to Backlog status
 
 
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -4,7 +4,7 @@ This document outlines our approach to triaging issues in GitHub, including guid
 
 **We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
 
-See [Jump to it](#issue-grooming) below for details on how to prioritize `earthaccess` issues and browse these via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
+See [The issue is groomed](#issue-grooming) section below for details on how to identify and browse prioritized issues via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
 
 
 ## Issue Lifecycle

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -2,7 +2,7 @@
 
 This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, and best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 
-**We hope that this guide will help empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
+**We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
 
 ## Issue Lifecycle
 
@@ -16,8 +16,9 @@ This document outlines our approach to triaging issues on GitHub, including guid
     * Adding an issue prioritization.
 
     * Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
-4. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
-5. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
+
+3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
 
     * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -55,43 +55,13 @@ When closing an issue as not planned:
 
 #### Labeling issues
 
-When labeling an issue, choose the label(s) that best describes the issue. Using labels consistently and accurately ensures that issues are trackable and searchable.
+When labeling an issue, choose the [label(s)](https://github.com/earthaccess-dev/earthaccess/labels) that best describes the issue. Using labels consistently and accurately ensures that issues are trackable and searchable. 
+
+Labels are mainly categorized by the prefix `type:`, `impact:`, or `needs:`. 
+Impact labels describe what portion of the project they affect. Impact labels are also used to help group related issues based on a particular feature or topic. For example, **impact: virtual-datasets** is used to categorize Issues or Discussions related to virtualizarr integration and support. These labels may evolve over time as new features are worked. 
 
 Refer to the [Labels](https://github.com/earthaccess-dev/earthaccess/labels) page for details on label types and descriptions. 
 
-### Issue Types
-
-- **type: bug**: Use for issues that identify bugs causing incorrect or unexpected behavior. This label is applied automatically if the [Bug template](https://github.com/earthaccess-dev/earthaccess/issues/new?template=bug.yml) is used.
-- **type: decision record**: Use this label for issues and PR's that address a new decision record document (e.g. https://github.com/earthaccess-dev/earthaccess/pull/1047).   
-- **type: duplicate**: Use this label for issues that are duplicates of existing ones.
-- **type: enhancement**: Use this label for requests for new features or improvements to existing functionalities.
-- **type: experience report**: Use this label for issues that describe a firsthand usability experience. 
-- **type: metrics**: This label is automatically applied upon creation of the Monthly metrics issue. See the [Monthly issue metrics](https://github.com/earthaccess-dev/earthaccess/blob/main/.github/workflows/issue-metrics.yml) action for more details.  
-- **type: will not do**: Use this label for issues that won’t be addressed or fixed.
-
-### Impact labels
-
-These labels describe what portion of the project they affect:
-
-- **impact: breaking**: Issues that break our public API.
-- **impact: core**: Issues that affect the core Python codebase.
-- **impact: dependencies**: Use this label for issues concerning dependencies.
-- **impact: documentation**: Use this label for issues related to documentation.
-- **impact: automation**: Use this label for issues related to the CI/CD pipeline or automation.
-- **impact: governance**: Issues that impact the project's governance or decision-making process.
-
-Impact labels are also used to help group related issues based on a particular feature or topic. For example, **impact: virtual-datasets** is used to categorize Issues or Discussions related to virtualizarr integration and support. These labels may evolve over time as new features are worked. 
-
-### Needs labels
-
-- **needs: decision**: We're struggling to decide what to do and the decision committee needs to help.
-- **needs: feedback**:  Use this label for issues where feedback is requested from the team or our community.
-- **needs: help**: Use this label for issues where additional help or contributions are needed.
-- **needs: triage**: Use this label for new issues that require additional information to determine whether it should move to the backlog, or close as not planned. 
-
-### Special labels
-
-- **good first issue**: Use this label for issues that are suitable for new contributors. These issues are designed to be approachable and not overly complex, making them an ideal starting point for those looking to contribute to the project.
 
 ## Linking Labels in GitHub Markdown
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -7,12 +7,12 @@ This document outlines our approach to triaging issues on GitHub, including guid
 ## Issue Lifecycle
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
-2. The issue is triaged by a community member in order to: 
-   * Determine whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
-   * Add or adjust issue labels.
-   * Add an issue prioritization. 
-   * Respond and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
-3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
+2. Issue triaging is led by the `earthaccess` community manager, though any community member is welcome and encouraged to contribute. Triaging involves:
+   * Determining whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
+   * Adding or adjusting issue labels.
+   * Adding an issue prioritization. 
+   * Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
+3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
    * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
    * Update status to `In Progress`.

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -15,7 +15,9 @@ Details on each of these workflow steps are provided below.
 
 ### A new issue is created
 
+Issues are created using one of several templates or as a blank issue. See the issue template choices [here](https://github.com/earthaccess-dev/earthaccess/issues/new/choose). When an issue is first created, provide initial acknowledgement and gratitude for the submission as a text or emoji response. 
 
+By default, all new issues are created without a project status. Issues without a status are listed in the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view. 
 
 ### The issue is triaged
 
@@ -26,16 +28,16 @@ Triaging is led by the `earthaccess` community manager, though any community mem
 - Adding an issue prioritization.
 - Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
 
-By default, all new issues are created without a project status. Issues without a status are listed in the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view. Statuses include:
+#### Moving an issue to backlog status
+
+When triaging a new issue, review the information and provide a response or follow up with question(s) if needed. Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. If you are unsure, add the **needs: triage** label. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Statuses include:
 
 - Backlog
 - In Progress
 - In Review
 - Done
 
-#### Moving an issue to backlog status
-
-When triaging a new issue, review the information and provide a response or follow up with question(s) if needed. Provide gratitude for the submission as a text or emoji response. Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. If you are unsure, add the **needs: triage** label. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views. 
+Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views. 
 
 #### When to "Close as not planned"?
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -4,7 +4,7 @@ This document outlines our approach to triaging issues in GitHub, including guid
 
 **We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
 
-See [The issue is groomed](#issue-grooming) section below for details on how to identify and browse prioritized issues via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
+See the [Issue grooming](#issue-grooming) section below for details on how to identify and browse prioritized issues via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
 
 
 ## Issue Lifecycle
@@ -16,13 +16,13 @@ See [The issue is groomed](#issue-grooming) section below for details on how to 
 
 Details on each of these workflow steps are provided below. 
 
-## A new issue is created
+## Issue creation
 
 Issues are created using one of several templates or as a blank issue. See the issue template choices [here](https://github.com/earthaccess-dev/earthaccess/issues/new/choose). When an issue is first created, provide initial acknowledgement and gratitude for the submission as a text or emoji response. 
 
 By default, all new issues are created without a project status. Issues without a status are listed in the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view. 
 
-## The issue is triaged
+## Issue triaging
 
 Triaging is led by the `earthaccess` community manager, though any community member is welcome and encouraged to contribute. Triaging involves:
 
@@ -76,11 +76,20 @@ https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 ```
 
 <a name="issue-grooming"></a>
-## The issue is groomed
+## Issue grooming
 
-TODO: Under the groomed section, have more of an intro or sub section on prioritizing issues. Then we can introduce the project views and how they are used, thinking about the contributor audience in addition to triager.
+Issues are groomed periodically to organize and prioritize the backlog. This issue management occurs within the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). Several views exist to serve various use cases, including:
 
-Issues are groomed periodically to organize and prioritize the backlog. Issue priorities are surfaced within the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views. When triaging a new issue, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
+- [Needs triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3): All issues without a status, awaiting triaging.
+- [Backlog](https://github.com/orgs/earthaccess-dev/projects/1/views/1): All issues with a `Backlog` status: These issues were triaged and are ready to be addressed.
+- [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4): All open, triaged issues with a `Bug` label.
+- [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6): All open issues with a `impact: documentation` label.
+- [Decisions](https://github.com/orgs/earthaccess-dev/projects/1/views/2): All issues with a `needs: decision` label. This is a "Board" type allowing us to see the status of all decisions.
+- [Roadmap](https://github.com/orgs/earthaccess-dev/projects/1/views/5): All issues linked and grouped by [Milestones](https://github.com/earthaccess-dev/earthaccess/milestones).
+
+If you're interested in contributing but aren't sure what needs attention, head to the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views to identify high-priority issues to address. 
+
+For triagers, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
 
 ### Priority: `1 - Critical`
 
@@ -125,7 +134,7 @@ The issue is a real improvement but not urgent.
 - Priority reflects *impact and urgency*, not effort — a quick fix can still be High priority.
 
 
-## The issue is worked as a new pull request
+## Working issues
 
 - [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
 - Update status to `In Progress`.
@@ -150,8 +159,8 @@ flowchart TD
   repro == NO ==> close3[Ask for details from reporter or close as not planned]
   repro == YES ==> real{Is actually a bug?}
   real == NO ==> intended{Is the intended behaviour?}
-  intended == YES ==> explain[Explain and close point to docs if needed]
-  intended == NO ==> open[Keep open for discussion Remove 'pending triage' label]
+  intended == YES ==> explain[Explain and close; point to docs if needed]
+  intended == NO ==> open[Keep open for discussion; Remove 'needs: triage' label]
   real == YES ==> real2["Confirm that 'Bug' label was automatically added as part of the Bug Issue template, otherwise add 'Bug' label."]
 
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -129,7 +129,7 @@ The issue is a real improvement but not urgent.
 
 ### Notes for Triagers
 
-- **When in doubt, start at Medium** and adjust based on community feedback or additional context.
+- **When in doubt, start at Important** and adjust based on community feedback or additional context.
 - The [User Guide](https://earthaccess.readthedocs.io/en/stable/user/) and [API Reference](https://earthaccess.readthedocs.io/en/stable/api/) generally warrant higher priority than contributing or developer docs when impact is otherwise similar.
 - Priority reflects *impact and urgency*, not effort — a quick fix can still be High priority.
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -141,7 +141,7 @@ flowchart TD
   start == YES ==> dupe{Is duplicate?}
   dupe == YES ==> close2[Close and point to duplicate]
   dupe == NO ==> repro{Has proper reproduction?}
-  repro == NO ==> close3[Label: 'needs reproduction' bot will auto close if no update has been made in 3 days]
+  repro == NO ==> close3[Ask for details from reporter or close as not planned]
   repro == YES ==> real{Is actually a bug?}
   real == NO ==> intended{Is the intended behaviour?}
   intended == YES ==> explain[Explain and close point to docs if needed]

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -8,16 +8,24 @@ This document outlines our approach to triaging issues on GitHub, including guid
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
 2. Issue triaging is led by the `earthaccess` community manager, though any community member is welcome and encouraged to contribute. Triaging involves:
-   * Determining whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
-   * Adding or adjusting issue labels.
-   * Adding an issue prioritization. 
-   * Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
-3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
-4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
-   * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
-   * Update status to `In Progress`.
-   * Link the issue to the related PR with a comment "Resolves #N" (`N` is the issue number). The issue will auto-close when the PR is merged.
-   * If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
+
+    * Determining whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
+
+    * Adding or adjusting issue labels.
+
+    * Adding an issue prioritization.
+
+    * Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
+4. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+5. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
+
+    * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
+
+    * Update status to `In Progress`.
+
+    * Link the issue to the related PR with a comment "Resolves #N" (`N` is the issue number). The issue will auto-close when the PR is merged.
+
+    * If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
 
 Details on each of these workflow steps are provided below. 
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -2,16 +2,16 @@
 
 This document outlines our approach to triaging issues in GitHub, including guidelines for labeling and resolving issues, and best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker. 
 
-**We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
+!!! info
 
-See the [Issue grooming](#issue-grooming) section below for details on how to identify and browse prioritized issues via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
-
+    We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"
+    See the [Issue prioritization](#issue-prioritization) section below for details on how to identify and browse prioritized issues via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
 
 ## Issue lifecycle
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
-2. The issue is triaged to initially assess the reported issue and determine its priority.  
-3. The issue is reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+2. The issue is triaged to initially assess the reported issue as a backlog candidate. 
+3. The issue is reviewed and prioritized by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 4. The issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
 
 Details on each of these workflow steps are provided below. 
@@ -75,8 +75,8 @@ To link to a label in GitHub Markdown, copy-and-paste the URL to the label by ri
 https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 ```
 
-<a name="issue-grooming"></a>
-## Issue grooming
+<a name="issue-prioritization"></a>
+## Issue prioritization
 
 Issues are groomed periodically to organize and prioritize the backlog. This issue management occurs within the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). Several views exist to serve various use cases, including:
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -13,13 +13,13 @@ This document outlines our approach to triaging issues in GitHub, including guid
 
 Details on each of these workflow steps are provided below. 
 
-### A new issue is created
+## A new issue is created
 
 Issues are created using one of several templates or as a blank issue. See the issue template choices [here](https://github.com/earthaccess-dev/earthaccess/issues/new/choose). When an issue is first created, provide initial acknowledgement and gratitude for the submission as a text or emoji response. 
 
 By default, all new issues are created without a project status. Issues without a status are listed in the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view. 
 
-### The issue is triaged
+## The issue is triaged
 
 Triaging is led by the `earthaccess` community manager, though any community member is welcome and encouraged to contribute. Triaging involves:
 
@@ -28,7 +28,7 @@ Triaging is led by the `earthaccess` community manager, though any community mem
 - Adding an issue prioritization.
 - Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
 
-#### Moving an issue to backlog status
+### Moving an issue to backlog status
 
 When triaging a new issue, review the information and provide a response or follow up with question(s) if needed. Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. If you are unsure, add the **needs: triage** label. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Statuses include:
 
@@ -39,7 +39,7 @@ When triaging a new issue, review the information and provide a response or foll
 
 Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views. 
 
-#### When to "Close as not planned"?
+### When to "Close as not planned"?
 
 Close issues as "not planned" when:
 
@@ -53,7 +53,7 @@ When closing an issue as not planned:
 - Offer alternative solutions or workarounds, if possible.
 - Link to relevant documentation or resources, if applicable.
 
-#### Labeling issues
+### Labeling issues
 
 When labeling an issue, choose the [label(s)](https://github.com/earthaccess-dev/earthaccess/labels) that best describes the issue. Using labels consistently and accurately ensures that issues are trackable and searchable. 
 
@@ -62,7 +62,7 @@ Impact labels describe what portion of the project they affect. Impact labels ar
 
 Refer to the [Labels](https://github.com/earthaccess-dev/earthaccess/labels) page for details on label types and descriptions. 
 
-##### Linking Labels in GitHub Markdown
+#### Linking Labels in GitHub Markdown
 
 When referencing a label in a GitHub issue or discussion, it is useful to link to the label page to provide additional context and help other members to quickly understand the issue's category.
 
@@ -72,11 +72,11 @@ To link to a label in GitHub Markdown, copy-and-paste the URL to the label by ri
 https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 ```
 
-### The issue is groomed
+## The issue is groomed
 
 Issues are groomed periodically to organize and prioritize the backlog. Issue priorities are surfaced within the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views. When triaging a new issue, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
 
-#### Priority: `1 - Critical`
+### Priority: `1 - Critical`
 
 The issue has significant, immediate impact on users and/or major components of the `earthaccess` library. 
 
@@ -88,7 +88,7 @@ The issue has significant, immediate impact on users and/or major components of 
 
 *Documentation example:* Content is incorrect or missing in a way that would immediately block or mislead a user.
 
-#### Priority: `2 - Important`
+### Priority: `2 - Important`
 
 The issue has real impact but is not immediately blocking a majority of users.
 
@@ -100,7 +100,7 @@ The issue has real impact but is not immediately blocking a majority of users.
 
 *Documentation example:* A Tutorial or secondary documentation is broken or unclear; contributing docs with significant usability issues.
 
-#### Priority: `3 - Nice to have` 
+### Priority: `3 - Nice to have` 
 
 The issue is a real improvement but not urgent.
 
@@ -112,14 +112,14 @@ The issue is a real improvement but not urgent.
 
 *Documentation example:* Minor inconsistencies, typos, or style issues; improvements to contributing or developer-facing docs with no impact on end-user workflows.
 
-#### Notes for Triagers
+### Notes for Triagers
 
 - **When in doubt, start at Medium** and adjust based on community feedback or additional context.
 - The [User Guide](https://earthaccess.readthedocs.io/en/stable/user/) and [API Reference](https://earthaccess.readthedocs.io/en/stable/api/) generally warrant higher priority than contributing or developer docs when impact is otherwise similar.
 - Priority reflects *impact and urgency*, not effort — a quick fix can still be High priority.
 
 
-### The issue is worked as a new pull request
+## The issue is worked as a new pull request
 
 - [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
 - Update status to `In Progress`.

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -187,28 +187,7 @@ flowchart TD
 ```
 
 
-## Discussions vs Issues
-TODO Move to https://earthaccess.readthedocs.io/en/latest/contributor/ ?
-
-This section would cover the guidelines for when to use discussions versus issues, and how to migrate between them.
-
-###  What are Discussions?
-
-Discussions are used for:
-
-- Brainstorming and idea generation.
-- Project feedback.
-- General questions and topics.
-
-###  What are Issues?
-
-Issues are used for:
-
-- Reporting bugs and errors.
-- Tracking progress on specific tasks or projects.
-- Requesting changes or improvements.
-
-### When to Migrate
+## Migrating between Discussions vs Issues
 
 Use your best judgement when migrating between issues and discussions. Sometimes it makes more sense to open a new issue or discussion instead of migrating, for example when there are many things being discussed, but we want to create an issue or task out of just one of those things.
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -4,7 +4,8 @@ This document outlines our approach to triaging issues in GitHub, including guid
 
 **We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
 
-See {ref}`issue-grooming` below for details on how to prioritize `earthaccess` issues and browse these via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
+See [Jump to it](#issue-grooming) below for details on how to prioritize `earthaccess` issues and browse these via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1).
+
 
 ## Issue Lifecycle
 
@@ -74,7 +75,7 @@ To link to a label in GitHub Markdown, copy-and-paste the URL to the label by ri
 https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 ```
 
-(issue-grooming)=
+<a name="issue-grooming"></a>
 ## The issue is groomed
 
 TODO: Under the groomed section, have more of an intro or sub section on prioritizing issues. Then we can introduce the project views and how they are used, thinking about the contributor audience in addition to triager.

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -65,7 +65,7 @@ Impact labels describe what portion of the project they affect. Impact labels ar
 
 Refer to the [Labels](https://github.com/earthaccess-dev/earthaccess/labels) page for details on label types and descriptions. 
 
-#### Linking Labels in GitHub Markdown
+#### Linking labels in GitHub Markdown
 
 When referencing a label in a GitHub issue or discussion, it is useful to link to the label page to provide additional context and help other members to quickly understand the issue's category.
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -1,6 +1,6 @@
 # Issue Triaging and Prioritization Guide
 
-This document outlines our approach to triaging issues on GitHub, including guidelines for labeling and resolving issues, and best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+This document outlines our approach to triaging issues in GitHub, including guidelines for labeling and resolving issues, and best practices for maintaining a well-organized, prioritized, and up-to-date issue tracker via the [`earthaccess` GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
 
 **We hope that this guide will empower anyone to contribute to issue triaging, and address a common question for contributors: "I'm interested in working on the highest priority issues that will solve important problems facing the `earthaccess` community. Where do I begin?"**
 
@@ -62,22 +62,11 @@ Impact labels describe what portion of the project they affect. Impact labels ar
 
 Refer to the [Labels](https://github.com/earthaccess-dev/earthaccess/labels) page for details on label types and descriptions. 
 
+##### Linking Labels in GitHub Markdown
 
-## Linking Labels in GitHub Markdown
+When referencing a label in a GitHub issue or discussion, it is useful to link to the label page to provide additional context and help other members to quickly understand the issue's category.
 
-When referencing a label in a GitHub issue or discussion, it will be  useful to link to the label page to provide additional context and help other members to quickly understand the issue's category.
-
-### Syntax
-
-To link to a label in GitHub Markdown, copy-and-paste the URL to the label by right-clicking [any label](https://github.com/earthaccess-dev/earthaccess/labels) and selecting "Copy Link". Then, paste that label in a GitHub issue, PR, discussion, or Markdown document:
-
-```
-https://github.com/username/repository/labels/label-name
-```
-
-### Example
-
-For example, to link to the "good first issue" label in the earthaccess-dev/earthaccess repository, you would use the URL:
+To link to a label in GitHub Markdown, copy-and-paste the URL to the label by right-clicking [any label](https://github.com/earthaccess-dev/earthaccess/labels) and selecting "Copy Link". Then, paste that label in a GitHub issue, PR, discussion, or Markdown document. For example, to link to the "good first issue" label in the earthaccess-dev/earthaccess repository, you would use the URL:
 
 ```
 https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
@@ -85,39 +74,9 @@ https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 
 ### The issue is groomed
 
+Issues are groomed periodically to organize and prioritize the backlog. Issue priorities are surfaced within the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views. When triaging a new issue, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
 
-
-### The issue is worked as a new pull request
-
-    * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
-
-    * Update status to `In Progress`.
-
-    * Link the issue to the related PR with a comment "Resolves #N" (`N` is the issue number). The issue will auto-close when the PR is merged.
-
-    * If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
-
-
-
-### Project status
-
-
-
-
-
-
-
-
-
-
-
-
-
-## Issue Prioritization
-
-Issue priorities are surfaced within the [Bug Priority](https://github.com/orgs/earthaccess-dev/projects/1/views/4) and [Docs](https://github.com/orgs/earthaccess-dev/projects/1/views/6) project views. When triaging a new issue, select a priority based on the user impact and urgency. The following guidelines apply broadly across issue types, with additional notes for bugs and documentation issues.
-
-### Priority: `1 - Critical`
+#### Priority: `1 - Critical`
 
 The issue has significant, immediate impact on users and/or major components of the `earthaccess` library. 
 
@@ -129,7 +88,7 @@ The issue has significant, immediate impact on users and/or major components of 
 
 *Documentation example:* Content is incorrect or missing in a way that would immediately block or mislead a user.
 
-### Priority: `2 - Important`
+#### Priority: `2 - Important`
 
 The issue has real impact but is not immediately blocking a majority of users.
 
@@ -141,7 +100,7 @@ The issue has real impact but is not immediately blocking a majority of users.
 
 *Documentation example:* A Tutorial or secondary documentation is broken or unclear; contributing docs with significant usability issues.
 
-### Priority: `3 - Nice to have` 
+#### Priority: `3 - Nice to have` 
 
 The issue is a real improvement but not urgent.
 
@@ -153,11 +112,20 @@ The issue is a real improvement but not urgent.
 
 *Documentation example:* Minor inconsistencies, typos, or style issues; improvements to contributing or developer-facing docs with no impact on end-user workflows.
 
-### Notes for Triagers
+#### Notes for Triagers
 
 - **When in doubt, start at Medium** and adjust based on community feedback or additional context.
 - The [User Guide](https://earthaccess.readthedocs.io/en/stable/user/) and [API Reference](https://earthaccess.readthedocs.io/en/stable/api/) generally warrant higher priority than contributing or developer docs when impact is otherwise similar.
 - Priority reflects *impact and urgency*, not effort — a quick fix can still be High priority.
+
+
+### The issue is worked as a new pull request
+
+- [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
+- Update status to `In Progress`.
+- Link the issue to the related PR with a comment "Resolves #N" (`N` is the issue number). The issue will auto-close when the PR is merged.
+- If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
+
 
 ## Issue Triaging Workflow
 

--- a/docs/contributor/triaging.md
+++ b/docs/contributor/triaging.md
@@ -7,46 +7,24 @@ This document outlines our approach to triaging issues on GitHub, including guid
 ## Issue Lifecycle
 
 1. A [new issue](https://github.com/earthaccess-dev/earthaccess/issues/new/choose) is created, either using a pre-existing template, or as a blank issue.
-2. An issue is triaged to initially assess the reported issue and determine its priority.  
-3. Issues are reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
-4. An issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
+2. The issue is triaged to initially assess the reported issue and determine its priority.  
+3. The issue is reviewed and groomed by the `earthaccess` community manager using the `earthaccess` [GitHub Project](https://github.com/orgs/earthaccess-dev/projects/1). 
+4. The issue is worked following the [Pull Request (PR) Guide](./pr-guide.md).
 
 Details on each of these workflow steps are provided below. 
 
 ### A new issue is created
 
-### An issue is triaged
+
+
+### The issue is triaged
 
 Triaging is led by the `earthaccess` community manager, though any community member is welcome and encouraged to contribute. Triaging involves:
 
-    * Determining whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
-
-    * Adding or adjusting issue labels.
-
-    * Adding an issue prioritization.
-
-    * Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
-
-### An issue is groomed
-
-### An issue is worked as a new pull request
-
-    * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
-
-    * Update status to `In Progress`.
-
-    * Link the issue to the related PR with a comment "Resolves #N" (`N` is the issue number). The issue will auto-close when the PR is merged.
-
-    * If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
-
-
-
-
-### Moving an issue to Backlog status
-
-
-
-### Project status
+- Determining whether the issue should be worked or not. If yes, move to "Backlog" status, otherwise close as not planned.
+- Adding or adjusting issue labels.
+- Adding an issue prioritization.
+- Responding and follow up as needed (i.e. tagging relevant earthaccess maintainers for further support).
 
 By default, all new issues are created without a project status. Issues without a status are listed in the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view. Statuses include:
 
@@ -55,10 +33,11 @@ By default, all new issues are created without a project status. Issues without 
 - In Review
 - Done
 
-When triaging a new issue, review the information and provide a response or follow up with question(s) if needed. Providing gratitude for the submission as a text or emoji response is highly encouraged. Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. If you are unsure, add the **needs: triage** label. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views. 
+#### Moving an issue to backlog status
 
+When triaging a new issue, review the information and provide a response or follow up with question(s) if needed. Provide gratitude for the submission as a text or emoji response. Move the issue to the Backlog unless it ought to be closed as "not planned", as outlined below. If you are unsure, add the **needs: triage** label. On the righthand side of the issue page, the "Projects" section contains an `earthaccess` project box. Click "no status" to select the status options. Select "Backlog". This will move the project out of the [Needs Triage](https://github.com/orgs/earthaccess-dev/projects/1/views/3) project view into its relevant backlog view depending on issue type. See below for more details on these other project views. 
 
-### When to "Close as not planned"?
+#### When to "Close as not planned"?
 
 Close issues as "not planned" when:
 
@@ -71,13 +50,12 @@ When closing an issue as not planned:
 - Provide a clear explanation as to why the issue is not planned or feasible.
 - Offer alternative solutions or workarounds, if possible.
 - Link to relevant documentation or resources, if applicable.
-- Add the **type: will not do** label.
 
-
-## Labeling Issues
+#### Labeling issues
 
 When labeling an issue, choose the label(s) that best describes the issue. Using labels consistently and accurately ensures that issues are trackable and searchable.
 
+Refer to the [Labels](https://github.com/earthaccess-dev/earthaccess/labels) page for details on label types and descriptions. 
 
 ### Issue Types
 
@@ -132,6 +110,36 @@ For example, to link to the "good first issue" label in the earthaccess-dev/eart
 ```
 https://github.com/earthaccess-dev/earthaccess/labels/good%20first%20issue
 ```
+
+### The issue is groomed
+
+
+
+### The issue is worked as a new pull request
+
+    * [Assign](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/assigning-issues-and-pull-requests-to-other-github-users) the issue to the implementer.
+
+    * Update status to `In Progress`.
+
+    * Link the issue to the related PR with a comment "Resolves #N" (`N` is the issue number). The issue will auto-close when the PR is merged.
+
+    * If the previous step is missed, [link any related PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) before manually closing an issue.
+
+
+
+### Project status
+
+
+
+
+
+
+
+
+
+
+
+
 
 ## Issue Prioritization
 


### PR DESCRIPTION
## Description

Resolves #1070 and based on recent discussions at the Collab cafe with @saberbrasher on incorporating prioritization best practices, GitHub project management, and overall triaging workflow into the [Triaging Guide](https://earthaccess.readthedocs.io/en/stable/contributor/triaging/).

This guide now begins with an issue lifecycle overview, and describes those lifecycle steps in detail with a focus on issue triaging and prioritization. This guide is also meant to help contributors understand our prioritization process and criteria, and how to find prioritized issues in our GitHub project.

---

#### "Ready for review" checklist

- [x] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [ ] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [x] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1308.org.readthedocs.build/en/1308/

<!-- readthedocs-preview earthaccess end -->