### PR TITLE
Enabled PD (pandas-vet)  and PYI (flake8-pyi) rulesets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,9 +232,6 @@ ignore = [
   "FIX002",
   "FURB122",
   "INP001",
-  "PD002",
-  "PD010",
-  "PD011",
   "PERF401",
   "PERF403",
   "PGH003",
@@ -249,8 +246,6 @@ ignore = [
   "PT012",
   "PT017",
   "PT027",
-  "PYI041",
-  "PYI066",
   "RUF002",
   "RUF012",
   "RUF015",
@@ -281,7 +276,7 @@ combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
 # Allow `print` and `pprint` in notebooks
-"*.ipynb" = ["T201", "T203", "N803", "RET504", "ERA001", "PLR2004"]
+"*.ipynb" = ["T201", "T203", "N803", "RET504", "ERA001", "PLR2004", "PD002", "PD010", "PD011"]
 "tests/**/*.py" = ["PLR2004"]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
Enabled  PD and PYI rulesets. Related to https://github.com/earthaccess-dev/earthaccess/issues/383.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1317.org.readthedocs.build/en/1317/

<!-- readthedocs-preview earthaccess end -->