### PR TITLE
docs: add example bugfix and feature PRs to contributor guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+- Add example bugfix and feature PR links to the contributor PR guide ([#530](https://github.com/earthaccess-dev/earthaccess/issues/530))
 - Allow for granule search for collection without SpatialExtent information ([@lsterzinger](https://github.com/lsterzinger))
 
 ### Changed

--- a/docs/contributor/pr-guide.md
+++ b/docs/contributor/pr-guide.md
@@ -93,6 +93,7 @@ relevant tab to proceed.
     - Create a branch to resolve your issue
     - Update the relevant code to fix the issue
     - If you're comfortable writing tests: create one or more new tests to demonstrate the bug, verify they fail before your fix, and pass after. It's fine to let PR CI/CD run the tests for you instead of running them locally.
+      [PR #923](https://github.com/earthaccess-dev/earthaccess/pull/923) is a small example: it fixes two `open_virtual_dataset` bugs and adds tests in `tests/integration/test_virtualizarr.py` that fail before the fix and pass after.
     - If you're **not** comfortable writing tests: that's OK! Open your PR anyway and note that you'd like help with tests. We'll work with you to get them added before merging.
     - Lint and format your code with [pre-commit](development.md#usage-of-pre-commit) (or comment `pre-commit.ci autofix` on your PR to have it done automatically)
     - Describe your changes in the `CHANGELOG.md`
@@ -104,6 +105,7 @@ relevant tab to proceed.
     - Create a branch for your new feature in your fork
     - Write the code to implement your new feature in a backwards compatible manner. If breaking changes are necessary, discuss your strategy with the team first.
     - If you're comfortable writing tests: create at least one test that exercises your feature. It's fine to let PR CI/CD run the test suite for you instead of running it locally.
+      [PR #1146](https://github.com/earthaccess-dev/earthaccess/pull/1146) is a small example: it adds the `LARC_CLOUD` provider to `daac_list` and adds an integration test that exercises it.
     - If you're **not** comfortable writing tests: that's OK! Open your PR anyway and note that you'd like help with tests. We'll work with you to get them added before merging.
     - Lint and format your code with [pre-commit](development.md#usage-of-pre-commit) (or comment `pre-commit.ci autofix` on your PR to have it done automatically)
     - Describe your changes in the `CHANGELOG.md`


### PR DESCRIPTION
## Summary

Adds two concrete example-PR links to `docs/contributor/pr-guide.md`, one under the "Fixing an Issue or Bug" path and one under "Contributing a New Feature". Both bullets are right where the issue asks ("at or near where we currently say 'create one or more new tests to demonstrate the bug' and 'create at least one test that exercises your feature'").

## Examples picked

Both are recently merged, small, explainable, and include unit/integration tests (the issue's three criteria).

- **Bug-fix example: PR #923** -- `Fix small open_virtual_dataset bugs`. +62 lines across 5 files, adds tests in `tests/integration/test_virtualizarr.py` that fail before the fix and pass after.
- **Feature example: PR #1146** -- `Add LARC_CLOUD provider to daac_list`. +14 lines across 2 files, adds an integration test in `tests/integration/test_cloud_download.py` that exercises the new provider.

## Files changed

- `docs/contributor/pr-guide.md` (+2 lines)
- `CHANGELOG.md` (+1 line under `[Unreleased]`)

Closes #530


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1328.org.readthedocs.build/en/1328/

<!-- readthedocs-preview earthaccess end -->