### PR TITLE
Enable BLE (flake8-blind-except) ruleset and fix violations

### DIFF
--- a/earthaccess/results.py
+++ b/earthaccess/results.py
@@ -416,7 +416,7 @@ class DataGranule(CustomDict):
                     if "ArchiveAndDistributionInformation" in data_granule
                 ],
             )
-        except Exception:
+        except Exception: # noqa: BLE001
             try:
                 data_granule = self["umm"]["DataGranule"]
                 total_size = sum(
@@ -426,7 +426,7 @@ class DataGranule(CustomDict):
                         if "ArchiveAndDistributionInformation" in data_granule
                     ],
                 ) / (1024 * 1024)
-            except Exception:
+            except Exception: # noqa: BLE001
                 total_size = 0
         return total_size
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -295,7 +295,7 @@ class Store:
                 timeout=1,
                 headers={"X-aws-ec2-metadata-token": token_.text},
             )
-        except Exception:
+        except Exception: # noqa: BLE001
             return False
 
         return resp.status_code == _HTTP_OK and resp.content == b"us-west-2"
@@ -353,7 +353,7 @@ class Store:
         """
         return self.get_s3_filesystem(daac, concept_id, provider, endpoint)
 
-    def get_s3_filesystem(
+    def get_s3_filesystem( # noqa: C901
         self,
         daac: str | None = None,
         concept_id: str | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,8 +210,6 @@ ignore = [
   "B019",
   "B023",
   "B905",
-  "BLE001",
-  "C901",
   "COM812",
   "D1",
   "D205",
@@ -253,7 +251,7 @@ combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
 # Allow `print` and `pprint` in notebooks
-"*.ipynb" = ["T201", "T203", "N803", "RET504", "ERA001", "PLR2004", "PD002", "PD010", "PD011", "EM"]
+"*.ipynb" = ["T201", "T203", "N803", "RET504", "ERA001", "PLR2004", "PD002", "PD010", "PD011", "EM", "BLE001"]
 "tests/**/*.py" = ["PLR2004"]
 
 [tool.ruff.lint.pydocstyle]

--- a/tests/integration/test_cloud_download.py
+++ b/tests/integration/test_cloud_download.py
@@ -111,7 +111,7 @@ def test_earthaccess_can_download_cloud_collection_granules(tmp_path, daac):
         try:
             # We are testing this method
             store.get(granules_to_download, local_path=path)
-        except Exception as e:
+        except Exception as e: # noqa: BLE001
             logger.warning(e)
 
         # test that we downloaded the mb reported by CMR

--- a/tests/unit/test_collection_queries.py
+++ b/tests/unit/test_collection_queries.py
@@ -77,8 +77,6 @@ def test_query_can_parse_single_dates(start, end, expected):
 @pytest.mark.parametrize("start,end,expected", invalid_single_dates)
 def test_query_can_handle_invalid_dates(start, end, expected):
     query = DataCollections()
-    try:
-        query = query.temporal(start, end)
-    except Exception as e:
-        assert isinstance(e, ValueError)
-        assert "temporal" not in query.params
+    assert "temporal" not in query.params
+    with pytest.raises(ValueError):
+        query.temporal(start, end)

--- a/tests/unit/test_granule_queries.py
+++ b/tests/unit/test_granule_queries.py
@@ -48,12 +48,9 @@ def test_query_can_parse_single_dates(start, end, expected):
 @pytest.mark.parametrize("start,end,expected", invalid_single_dates)
 def test_query_can_handle_invalid_dates(start, end, expected):
     granules = DataGranules().short_name("MODIS")
-    try:
-        granules = granules.temporal(start, end)
-    except Exception as e:
-        assert isinstance(e, ValueError)
-        assert "temporal" not in granules.params
-
+    assert "temporal" not in granules.params
+    with pytest.raises(ValueError):
+        granules.temporal(start, end)
 
 @pytest.mark.parametrize("bbox,expected", bbox_queries)
 def test_query_handles_bbox(bbox, expected):


### PR DESCRIPTION
Fixed errors and violations as a result of enabling BLE ruleset. Related to https://github.com/earthaccess-dev/earthaccess/issues/383.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1350.org.readthedocs.build/en/1350/

<!-- readthedocs-preview earthaccess end -->