### PR TITLE
Fix typo of "Block Size" in docs and optimize docstrings

### DIFF
--- a/docs/user/access.md
+++ b/docs/user/access.md
@@ -105,6 +105,6 @@ Two key parameters control the efficiency of file access; cache type and block-s
 
 | File Size |  | Block Size |
 |---------|--|----------|
-| Small | < 1000 MB | 4 MB |
+| Small | < 100 MB | 4 MB |
 | Medium | < 1 GB | 8 MB |
 | Large | > 1 GB | 16 MB |

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -113,8 +113,9 @@ def _optimal_fsspec_block_size(file_size: int) -> int:
 
     Uses `blockcache` for all files with block sizes adjusted by file size:
 
-    - <100MB: 4MB
-    - >100MB: 4-16MB
+    - <100MB:         4MB
+    - >=100MB, <1GB:  8MB
+    - >=1GB:         16MB
 
     Parameters:
         file_size (int): Size of the file in bytes.


### PR DESCRIPTION
<!--
IMPORTANT: Please open your PR in draft mode. Only mark it "Ready for review" after
completing the "Ready for review" checklist.

If you read the guide and your question isn't answered, please ping `@earthaccess-dev/maintainers` in a comment!
--->

## Description

Fix typo of "Block Size" in docs and optimize docstrings, make them corresponding with the code: 
https://github.com/earthaccess-dev/earthaccess/blob/b45b5d701f96c83af754ed0dbf701e0d90a0ab77/earthaccess/store.py#L109-L132

---

#### "Ready for review" checklist

- [x] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1353.org.readthedocs.build/en/1353/

<!-- readthedocs-preview earthaccess end -->