### PR TITLE
docs: surface a Get help section on the docs home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,17 @@ We can use `earthaccess` to do impactful science, faster:
 
 `earthaccess` is an open-source community effort under an [MIT license](LICENSE.txt).  We welcome contributions to improve `earthaccess`.  Please see the [Contributing Guide](contributor/index.md) to learn how to get involved.
 
+# Get help
+
+Have a question about working with NASA Earthdata, or run into something unexpected? Both users and contributors are welcome to reach out:
+
+- **[Zulip chat](https://earthaccess.zulipchat.com)**: ask questions and chat with users, developers, and maintainers.
+- **[Q&A Discussions](https://github.com/earthaccess-dev/earthaccess/discussions/categories/q-a)**: ask a question or share insights about Earth data access.
+- **[GitHub Issues](https://github.com/earthaccess-dev/earthaccess/issues)**: report a bug, unexpected behavior, or a stumbling block in the documentation.
+- **[Collaboration Café](calendar.md)**: join a regular community call to get help on, or give help with, anything related to Earth data access.
+
+If you're not sure where to start, just pick whichever fits best, and the community will help you out.
+
 # Supported by
 
 `earthaccess` is supported by [NASA](https://www.nasa.gov/), [Openscapes](https://openscapes.org/), [NSIDC](https://nsidc.org/), and other organizations. [See all supporters](supported-by.md).


### PR DESCRIPTION
## Summary

Surface the project's help channels (Zulip chat, Q&A Discussions, GitHub Issues, and the Collaboration Café) on the docs home page, so both users and contributors can find support from the page everyone lands on first.

## Why this matters

#1335 notes that these channels currently live only in the Contributor Guide (`docs/contributor/index.md`, lines 8-22) even though "both contributors and users need help." A user who lands on the docs home page has no obvious path to ask a question. The issue suggests surfacing this "in the overview section, near the top."

## Description

Adds a `# Get help` section to `docs/index.md`, between the "About earthaccess" overview and "Supported by". It reuses the channels already listed in the contributor guide and matches the home page's existing bold-term list style (the same shape as the "Search data / Access data / Authenticate" list directly above it). The Collaboration Café uses the relative `calendar.md` link, which resolves under the docs' `strict: true` build; the other links already appear elsewhere in the docs. No new page or nav entry was added, following the issue's "overview section" suggestion.

Resolves #1335

---

#### "Ready for review" checklist

- [x] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/pr-guide/)
- [ ] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1354.org.readthedocs.build/en/1354/

<!-- readthedocs-preview earthaccess end -->