### PR TITLE
Update broken link in pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ resolved in that text, for example "resolves #1".
 #### "Ready for review" checklist
 
 - [ ] Place this Pull Request (PR) in draft until it is ready for review (see below)
-- [ ] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/pr-guide/)
+- [ ] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/)
 - [ ] Mark "ready for review" after following instructions in the guide
 
 #### Merge checklist


### PR DESCRIPTION
## Description

A very small PR! I found a broken link in PR template:

Updated the checklist item:

`- [ ] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/pr-guide/)` 

to use the updated link: https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/

I'm not sure such a small change needs an update to the Changelog. Lmk if I should get it updated.

---

#### "Ready for review" checklist

- [ ] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x ] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/pr-guide/)
- [x ] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x ] PR title is descriptive
- [ ] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [ ] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval



<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1396.org.readthedocs.build/en/1396/

<!-- readthedocs-preview earthaccess end -->