### PR TITLE
Add MODIS Land Surface Temperature tutorial with rasterio and rasterstats

### DIFF
--- a/docs/user/tutorials/modis-land-surface-temperature.ipynb
+++ b/docs/user/tutorials/modis-land-surface-temperature.ipynb
@@ -1,0 +1,477 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+   "metadata": {},
+   "source": [
+    "# MODIS Land Surface Temperature: Search, Download, and Regional Analysis\n",
+    "\n",
+    "This tutorial demonstrates a complete workflow using `earthaccess` to retrieve **MODIS MOD11A2** (8-day Land Surface Temperature & Emissivity, 1 km) data and perform a regional analysis with `rasterio`, `geopandas`, and `rasterstats`.\n",
+    "\n",
+    "**What you will learn:**\n",
+    "- Authenticate with NASA Earthdata using `earthaccess`\n",
+    "- Search and download MODIS MOD11A2 HDF tiles by bounding box and date range\n",
+    "- Mosaic multi-tile data into a single raster\n",
+    "- Convert Kelvin to Celsius and reproject to WGS84\n",
+    "- Clip the raster to a regional boundary shapefile\n",
+    "- Compute district-level zonal statistics with `rasterstats`\n",
+    "- Visualise the results with `geopandas` and `matplotlib`\n",
+    "\n",
+    "**Dataset:** [MOD11A2 v061](https://doi.org/10.5067/MODIS/MOD11A2.061) — MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid\n",
+    "\n",
+    "**Prerequisites:**\n",
+    "- A free [NASA Earthdata account](https://urs.earthdata.nasa.gov/)\n",
+    "- The packages listed in the cell below\n",
+    "- A boundary shapefile for your region of interest (this example uses [GADM Pakistan Level 3](https://gadm.org/))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+   "metadata": {},
+   "source": [
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install earthaccess numpy geopandas matplotlib rasterio rasterstats GDAL affine pyogrio --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+   "metadata": {},
+   "source": [
+    "## 1. Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import re\n",
+    "import glob\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import geopandas as gpd\n",
+    "import rasterio\n",
+    "from rasterio.mask import mask\n",
+    "from osgeo import gdal\n",
+    "from rasterstats import zonal_stats\n",
+    "\n",
+    "import earthaccess\n",
+    "\n",
+    "print(f\"earthaccess version: {earthaccess.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8c9-d0e1-2345-fabc-456789012345",
+   "metadata": {},
+   "source": [
+    "## 2. Authenticate with NASA Earthdata\n",
+    "\n",
+    "`earthaccess.login()` looks for credentials in the following order:\n",
+    "1. `~/.netrc` file\n",
+    "2. `EARTHDATA_USERNAME` / `EARTHDATA_PASSWORD` environment variables\n",
+    "3. Interactive prompt (if `strategy='interactive'`)\n",
+    "\n",
+    "Register for a free account at [urs.earthdata.nasa.gov](https://urs.earthdata.nasa.gov/) if you do not have one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0-e1f2-3456-abcd-567890123456",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth = earthaccess.login()\n",
+    "print(\"Authentication successful:\", auth.authenticated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1-f2a3-4567-bcde-678901234567",
+   "metadata": {},
+   "source": [
+    "## 3. Configure the search parameters\n",
+    "\n",
+    "We search for **MOD11A2 v061** granules over Pakistan for April 2025.\n",
+    "\n",
+    "The bounding box covers Pakistan: `(min_lon, min_lat, max_lon, max_lat)` = `(60, 23, 78, 38)`.\n",
+    "\n",
+    "> **Tip:** You can find the MODIS sinusoidal tile IDs for any region using the [MODIS Tile Calculator](https://modis-land.appdata.nasa.gov/MODLAND_grid.html). Pakistan spans tiles h22–h25, v05–v06."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9d0e1f2-a3b4-5678-cdef-789012345678",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Output directories\n",
+    "base_dir = \"modis_lst_output\"\n",
+    "download_dir = os.path.join(base_dir, \"hdf\")\n",
+    "output_dir = os.path.join(base_dir, \"geotiff\")\n",
+    "os.makedirs(download_dir, exist_ok=True)\n",
+    "os.makedirs(output_dir, exist_ok=True)\n",
+    "\n",
+    "# Search parameters\n",
+    "SHORT_NAME = \"MOD11A2\"\n",
+    "VERSION = \"061\"\n",
+    "START_DATE = \"2025-04-01\"\n",
+    "END_DATE = \"2025-04-30\"\n",
+    "BOUNDING_BOX = (60, 23, 78, 38)  # Pakistan: (W, S, E, N)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3-b4c5-6789-defa-890123456789",
+   "metadata": {},
+   "source": [
+    "## 4. Search and download MODIS granules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4-c5d6-7890-efab-901234567890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = earthaccess.search_data(\n",
+    "    short_name=SHORT_NAME,\n",
+    "    version=VERSION,\n",
+    "    cloud_hosted=True,\n",
+    "    temporal=(START_DATE, END_DATE),\n",
+    "    bounding_box=BOUNDING_BOX,\n",
+    ")\n",
+    "print(f\"Found {len(results)} granules\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2a3b4c5-d6e7-8901-fabc-012345678901",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files = earthaccess.download(results, download_dir)\n",
+    "print(f\"Downloaded {len(files)} files to: {download_dir}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d6-e7f8-9012-abcd-123456789012",
+   "metadata": {},
+   "source": [
+    "## 5. Mosaic tiles into a single raster\n",
+    "\n",
+    "MODIS data is distributed as sinusoidal grid tiles. We group files by date, position each tile in a mosaic array, extract the `LST_Day_1km` subdataset, apply the scale factor (`× 0.02`), and convert from Kelvin to Celsius (`− 273.15`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7-f8a9-0123-bcde-234567890123",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Tile layout — adjust if your bounding box spans different tiles\n",
+    "TILE_POSITIONS = {\n",
+    "    \"h22v05\": (0, 0), \"h23v05\": (0, 1), \"h24v05\": (0, 2), \"h25v05\": (0, 3),\n",
+    "    \"h22v06\": (1, 0), \"h23v06\": (1, 1), \"h24v06\": (1, 2), \"h25v06\": (1, 3),\n",
+    "}\n",
+    "TILE_SIZE = 1200\n",
+    "mosaic_rows = max(p[0] for p in TILE_POSITIONS.values()) + 1\n",
+    "mosaic_cols = max(p[1] for p in TILE_POSITIONS.values()) + 1\n",
+    "mosaic_shape = (TILE_SIZE * mosaic_rows, TILE_SIZE * mosaic_cols)\n",
+    "\n",
+    "# Group HDF files by acquisition date\n",
+    "hdf_files = sorted(glob.glob(os.path.join(download_dir, \"*.hdf\")))\n",
+    "date_tile_dict = defaultdict(list)\n",
+    "pattern = re.compile(r\"MOD11A2\\.A(\\d{7})\\.(h\\d{2}v\\d{2})\\.\\d{3}\\.\\d{13}\\.hdf\")\n",
+    "\n",
+    "for f in hdf_files:\n",
+    "    m = pattern.search(os.path.basename(f))\n",
+    "    if m:\n",
+    "        date_tile_dict[m.group(1)].append((m.group(2), f))\n",
+    "\n",
+    "print(f\"Found {len(hdf_files)} HDF files across {len(date_tile_dict)} dates\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5d6e7f8-a9b0-1234-cdef-345678901234",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosaic_stack = []\n",
+    "valid_dates = []\n",
+    "first_gt = first_proj = None\n",
+    "\n",
+    "for date_str, tile_files in date_tile_dict.items():\n",
+    "    mosaic = np.full(mosaic_shape, np.nan, dtype=np.float32)\n",
+    "    n_tiles = 0\n",
+    "\n",
+    "    for tile, hdf_path in tile_files:\n",
+    "        if tile not in TILE_POSITIONS:\n",
+    "            continue\n",
+    "        hdf = gdal.Open(hdf_path)\n",
+    "        lst_path = next(\n",
+    "            (s[0] for s in hdf.GetSubDatasets() if \"LST_Day_1km\" in s[0]), None\n",
+    "        )\n",
+    "        if lst_path is None:\n",
+    "            continue\n",
+    "        ds = gdal.Open(lst_path)\n",
+    "        arr = ds.ReadAsArray().astype(np.float32)\n",
+    "        # Scale factor 0.02, convert K → °C; fill value 0 → NaN\n",
+    "        arr = np.where(arr == 0, np.nan, arr * 0.02 - 273.15)\n",
+    "        if first_gt is None:\n",
+    "            first_gt = ds.GetGeoTransform()\n",
+    "            first_proj = ds.GetProjection()\n",
+    "        row, col = TILE_POSITIONS[tile]\n",
+    "        mosaic[\n",
+    "            row * TILE_SIZE : row * TILE_SIZE + TILE_SIZE,\n",
+    "            col * TILE_SIZE : col * TILE_SIZE + TILE_SIZE,\n",
+    "        ] = arr\n",
+    "        n_tiles += 1\n",
+    "\n",
+    "    if n_tiles > 0:\n",
+    "        mosaic_stack.append(mosaic)\n",
+    "        valid_dates.append(date_str)\n",
+    "        print(f\"  {date_str}: mosaicked {n_tiles} tiles\")\n",
+    "\n",
+    "print(f\"\\nTotal composites: {len(mosaic_stack)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6e7f8a9-b0c1-2345-defa-456789012345",
+   "metadata": {},
+   "source": [
+    "## 6. Compute mean LST and save as GeoTIFF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7f8a9b0-c1d2-3456-efab-567890123456",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stacked = np.stack(mosaic_stack)\n",
+    "mean_lst = np.nanmean(stacked, axis=0)\n",
+    "\n",
+    "print(f\"Mean LST range: {np.nanmin(mean_lst):.1f}°C to {np.nanmax(mean_lst):.1f}°C\")\n",
+    "print(f\"Date range: {valid_dates[0]} → {valid_dates[-1]}\")\n",
+    "\n",
+    "# Save as unprojected GeoTIFF\n",
+    "temp_unproj = os.path.join(output_dir, \"mean_lst_sinusoidal.tif\")\n",
+    "driver = gdal.GetDriverByName(\"GTiff\")\n",
+    "out_ds = driver.Create(temp_unproj, mosaic_shape[1], mosaic_shape[0], 1, gdal.GDT_Float32)\n",
+    "out_ds.SetGeoTransform(first_gt)\n",
+    "out_ds.SetProjection(first_proj)\n",
+    "out_ds.GetRasterBand(1).WriteArray(mean_lst)\n",
+    "out_ds.GetRasterBand(1).SetNoDataValue(float(\"nan\"))\n",
+    "out_ds.FlushCache()\n",
+    "del out_ds\n",
+    "\n",
+    "# Reproject to WGS84 (EPSG:4326)\n",
+    "temp_wgs84 = os.path.join(output_dir, \"mean_lst_wgs84.tif\")\n",
+    "gdal.Warp(temp_wgs84, temp_unproj, dstSRS=\"EPSG:4326\")\n",
+    "print(\"Reprojected raster saved to:\", temp_wgs84)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a9b0c1-d2e3-4567-fabc-678901234567",
+   "metadata": {},
+   "source": [
+    "## 7. Clip raster to a regional boundary\n",
+    "\n",
+    "Load your boundary shapefile and clip the raster to the region of interest. Here we use the GADM Pakistan Level-3 boundary (district level). Download it from [gadm.org](https://gadm.org/download_country.html) and place it alongside this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9b0c1d2-e3f4-5678-abcd-789012345678",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load boundary — replace the path with your own shapefile\n",
+    "SHAPEFILE = \"gadm41_PAK_3.shp\"  # GADM Pakistan Level-3 districts\n",
+    "gdf = gpd.read_file(SHAPEFILE).to_crs(\"EPSG:4326\")\n",
+    "region_geom = [gdf.union_all().__geo_interface__]\n",
+    "\n",
+    "with rasterio.open(temp_wgs84) as src:\n",
+    "    clipped, clipped_transform = mask(src, region_geom, crop=True)\n",
+    "    meta = src.meta.copy()\n",
+    "    meta.update(\n",
+    "        height=clipped.shape[1],\n",
+    "        width=clipped.shape[2],\n",
+    "        transform=clipped_transform,\n",
+    "    )\n",
+    "\n",
+    "clipped_path = os.path.join(output_dir, \"mean_lst_clipped.tif\")\n",
+    "with rasterio.open(clipped_path, \"w\", **meta) as dst:\n",
+    "    dst.write(clipped)\n",
+    "\n",
+    "print(\"Clipped raster saved to:\", clipped_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c1d2e3-f4a5-6789-bcde-890123456789",
+   "metadata": {},
+   "source": [
+    "## 8. Compute district-level zonal statistics\n",
+    "\n",
+    "`rasterstats.zonal_stats` calculates summary statistics (mean, min, max, etc.) for each polygon in the boundary GeoDataFrame against the clipped raster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1d2e3f4-a5b6-7890-cdef-901234567890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stats = zonal_stats(gdf, clipped_path, stats=[\"mean\", \"min\", \"max\"], geojson_out=False)\n",
+    "gdf[\"mean_LST_C\"] = [s[\"mean\"] for s in stats]\n",
+    "gdf[\"min_LST_C\"] = [s[\"min\"] for s in stats]\n",
+    "gdf[\"max_LST_C\"] = [s[\"max\"] for s in stats]\n",
+    "\n",
+    "print(\"Top 5 hottest districts:\")\n",
+    "print(gdf[[\"NAME_3\", \"mean_LST_C\"]].nlargest(5, \"mean_LST_C\").to_string(index=False))\n",
+    "print(\"\\nTop 5 coldest districts:\")\n",
+    "print(gdf[[\"NAME_3\", \"mean_LST_C\"]].nsmallest(5, \"mean_LST_C\").to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e3f4a5-b6c7-8901-defa-012345678901",
+   "metadata": {},
+   "source": [
+    "## 9. Visualise the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3f4a5b6-c7d8-9012-efab-123456789012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, figsize=(16, 7))\n",
+    "\n",
+    "# Map: district-level mean LST\n",
+    "gdf.plot(\n",
+    "    column=\"mean_LST_C\",\n",
+    "    cmap=\"RdYlBu_r\",\n",
+    "    legend=True,\n",
+    "    edgecolor=\"black\",\n",
+    "    linewidth=0.3,\n",
+    "    ax=axes[0],\n",
+    "    legend_kwds={\"label\": \"Mean LST (°C)\"},\n",
+    ")\n",
+    "axes[0].set_title(f\"Mean Land Surface Temperature — {START_DATE[:7]}\", fontsize=13)\n",
+    "axes[0].set_xlabel(\"Longitude\")\n",
+    "axes[0].set_ylabel(\"Latitude\")\n",
+    "axes[0].axis(\"on\")\n",
+    "\n",
+    "# Bar chart: top 10 hottest vs coldest\n",
+    "top10_hot = gdf.nlargest(10, \"mean_LST_C\")\n",
+    "top10_cold = gdf.nsmallest(10, \"mean_LST_C\")\n",
+    "\n",
+    "axes[1].barh(top10_hot[\"NAME_3\"], top10_hot[\"mean_LST_C\"], color=\"#d62728\", label=\"Hottest\")\n",
+    "axes[1].barh(top10_cold[\"NAME_3\"], top10_cold[\"mean_LST_C\"], color=\"#1f77b4\", label=\"Coldest\")\n",
+    "axes[1].set_xlabel(\"Mean LST (°C)\")\n",
+    "axes[1].set_title(\"Top 10 Hottest & Coldest Districts\", fontsize=13)\n",
+    "axes[1].legend()\n",
+    "axes[1].axvline(0, color=\"black\", linewidth=0.8, linestyle=\"--\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(os.path.join(output_dir, \"modis_lst_results.png\"), dpi=150, bbox_inches=\"tight\")\n",
+    "plt.show()\n",
+    "print(\"Figure saved.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4a5b6c7-d8e9-0123-fabc-234567890123",
+   "metadata": {},
+   "source": [
+    "## 10. Save vector output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5b6c7d8-e9f0-1234-abcd-345678901234",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_gpkg = os.path.join(output_dir, \"district_lst_stats.gpkg\")\n",
+    "gdf[[\"NAME_1\", \"NAME_2\", \"NAME_3\", \"mean_LST_C\", \"min_LST_C\", \"max_LST_C\", \"geometry\"]].to_file(\n",
+    "    output_gpkg, driver=\"GPKG\"\n",
+    ")\n",
+    "print(\"Vector output saved to:\", output_gpkg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6c7d8e9-f0a1-2345-bcde-456789012345",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this tutorial we:\n",
+    "\n",
+    "1. Used `earthaccess` to **search and download** 24 MODIS MOD11A2 HDF granules covering Pakistan in April 2025\n",
+    "2. **Mosaicked** multi-tile data and computed a mean LST composite, converting from raw digital numbers (Kelvin × 0.02) to degrees Celsius\n",
+    "3. **Reprojected** the result to WGS84 and **clipped** it to the Pakistan boundary\n",
+    "4. Computed **district-level zonal statistics** with `rasterstats` — identifying Kech (Balochistan) as the hottest district (~45.7 °C) and high-elevation Gilgit-Baltistan districts as the coldest\n",
+    "5. Saved both raster (GeoTIFF) and vector (GeoPackage) outputs\n",
+    "\n",
+    "The same workflow can be adapted to any region by changing `BOUNDING_BOX`, `START_DATE`/`END_DATE`, and the boundary shapefile. Other MODIS products (e.g., MOD13A2 for NDVI, MOD09GA for surface reflectance) can be used by changing `SHORT_NAME`.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Wan, Z., Hook, S., Hulley, G. (2021). *MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid V061*. NASA EOSDIS LP DAAC. <https://doi.org/10.5067/MODIS/MOD11A2.061>\n",
+    "- GADM (2023). *Database of Global Administrative Areas*. <https://gadm.org>\n",
+    "- earthaccess documentation: <https://earthaccess.readthedocs.io>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

This PR adds a new tutorial notebook demonstrating a complete MODIS LST workflow using earthaccess.

**File:** \docs/user/tutorials/modis-land-surface-temperature.ipynb\

### What the tutorial covers
- Authenticate with NASA Earthdata using \earthaccess.login()\
- Search and download MODIS MOD11A2 v061 (8-day LST, 1 km) granules by bounding box and date range
- Mosaic multi-tile HDF data, apply scale factor (×0.02) and convert Kelvin → Celsius
- Reproject to WGS84 with GDAL
- Clip raster to a regional boundary with \asterio\
- Compute district-level zonal statistics with \asterstats\
- Visualise results with \geopandas\ and \matplotlib\

### Why this is useful
There is currently no MODIS-specific tutorial in the earthaccess docs. This fills that gap with a real end-to-end workflow that goes beyond search/download into actual raster processing — a common next step for users who find earthaccess through MODIS use cases (see also issue #1057).

The notebook is based on a working analysis of Pakistan Land Surface Temperature for April 2025 and has been tested in Google Colab.

### Related issues
- Addresses the documentation gap noted in #1057 (users switching to earthaccess for MODIS LST/NDVI workflows)

## Checklist
- [x] PR title is descriptive
- [x] New tutorial follows existing naming convention (\emit-earthaccess.ipynb\, etc.)
- [x] No new dependencies beyond what earthaccess already recommends
- [ ] CHANGELOG.md updated (happy to add if maintainers point me to the right section)

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1398.org.readthedocs.build/en/1398/

<!-- readthedocs-preview earthaccess end -->