### PR TITLE
fix: set allow-unsafe-pr-checkout to true

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -130,6 +130,14 @@ jobs:
           # this point.
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          # The previous step will exit with failure if the user does not have
+          # appropriate permissions, so only a maintainer can reach this step.
+          # Thus, an "unsafe PR checkout" should be safe, but this does REQUIRE
+          # a maintainer to deem the contributor's changes are safe BEFORE
+          # rerunning the failed (due to lack of permissions) integration tests.
+          # (This input was added to the checkout action v7, and defaults to
+          # false, so we must explicitly set it to true.)
+          allow-unsafe-pr-checkout: true
 
       - name: Install package with dependencies
         uses: ./.github/actions/install-pkg


### PR DESCRIPTION
<!--
IMPORTANT: Please open your PR in draft mode. Only mark it "Ready for review" after
completing the "Ready for review" checklist.

If you read the guide and your question isn't answered, please ping `@earthaccess-dev/maintainers` in a comment!
--->

## Description

**Until the PR lands, maintainers will be unable rerun failed integration tests.**

GitHub's checkout action added an allow-unsafe-pr-checkout input, set to false by default. We must explicitly set it to true to retain previous behavior, which we require.

We gate this by checking a contributor's permissions, so only maintainer's are permitted to run an "unsafe" PR checkout, putting responsibility on the maintainer to identify an unsafe contribution. Only safe code should be rerun by a maintainer through integration tests.

See https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

#### "Ready for review" checklist

- [ ] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [ ] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/)
- [ ] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [ ] PR title is descriptive
- [ ] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [ ] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval

> **Need help?** We welcome contributions at every experience level. You don't have to
> write tests alone — open your PR and ask for help. It's also fine to let GitHub run tests
> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
> instead of running them locally. If anything fails and you're not sure why, just
> mention `@earthaccess-dev/maintainers` in a comment and we'll work with you!


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1399.org.readthedocs.build/en/1399/

<!-- readthedocs-preview earthaccess end -->