### PR TITLE
Run zizmor on changes to actions in the `actions/` directory

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,9 +6,11 @@ on:
       - "main"
     paths:
       - ".github/workflows/*"
+      - ".github/actions/*"
   pull_request:
     paths:
       - ".github/workflows/*"
+      - ".github/actions/*"
 
 permissions: {}
 


### PR DESCRIPTION
## Description

https://github.com/earthaccess-dev/earthaccess/pull/1410 didn't run zizmor as it should have. This PR fixes that! I'm gonna YOLO merge.

---

#### "Ready for review" checklist

- [ ] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [ ] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/)
- [ ] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [ ] PR title is descriptive
- [ ] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [ ] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval

> **Need help?** We welcome contributions at every experience level. You don't have to
> write tests alone — open your PR and ask for help. It's also fine to let GitHub run tests
> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
> instead of running them locally. If anything fails and you're not sure why, just
> mention `@earthaccess-dev/maintainers` in a comment and we'll work with you!


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1413.org.readthedocs.build/en/1413/

<!-- readthedocs-preview earthaccess end -->