### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/earthaccess/formatters.py
+++ b/earthaccess/formatters.py
@@ -1,3 +1,4 @@
+from html import escape
 from typing import Any
 from uuid import uuid4
 
@@ -26,14 +27,14 @@ def _repr_granule_html(granule: Any) -> str:
     style = "max-height: 120px;"
     dataviz_img = "".join(
         [
-            f'<a href="{link}"><img style="{style}" src="{link}" alt="Data Preview"/></a>'
+            f'<a href="{escape(link)}"><img style="{style}" src="{escape(link)}" alt="Data Preview"/></a>'
             for link in granule.dataviz_links()[:2]
             if link.startswith("http")
         ],
     )
     data_links = "".join(
         [
-            f'<a href="{link}" target="_blank" class="btn btn-secondary btn-sm">{link.split("/")[-1]}</a>'
+            f'<a href="{escape(link)}" target="_blank" class="btn btn-secondary btn-sm">{escape(link.split("/")[-1])}</a>'
             for link in granule.data_links()
         ],
     )


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `Medium` | **File**: `earthaccess/formatters.py:L28`

In `_repr_granule_html`, data links and dataviz links from granule objects are directly interpolated into HTML string templates without any sanitization or escaping. If a granule's `data_links()` or `dataviz_links()` returns a malicious URL containing HTML/JavaScript (e.g., `"><script>alert(1)</script>`), it will be injected into the HTML output. In a Jupyter notebook environment, this could lead to execution of arbitrary JavaScript code (Cross-Site Scripting).

## Solution

Use an HTML escaping library (like `markupsafe.escape` or `html.escape`) on the `link` variables before injecting them into the HTML string templates.

## Changes

- `earthaccess/formatters.py` (modified)

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1416.org.readthedocs.build/en/1416/

<!-- readthedocs-preview earthaccess end -->