### PR TITLE
Ignore flaky wiki.esipfed.org FUNding Friday URL for 'check links' CI workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -33,3 +33,4 @@ jobs:
             ^https://www\.gnu\.org/software/inetutils/
             ^https://asdc\.larc\.nasa\.gov/project/TEMPO
             ^https://www\.jpl\.nasa\.gov/missions/surface-water-and-ocean-topography-swot/
+            ^https://wiki\.esipfed\.org/FUNding_Friday_Projects


### PR DESCRIPTION
## Description

The "Check links" automated CI workflow has been failing on most (if not all) of the currently open PRs because the `https://wiki.esipfed.org/FUNding_Friday_Projects` URL (linked from `docs/growing/esip-funding-friday-song-lyrics.md`) returns `403: Forbidden` to the link checker's bot user agent. The link is valid in a browser, so I don't think we should remove the link from the docs.

This PR adds that URL to the `ignore_links` list in the `check-links.yml` workflow file.

Closes #1442.

---

#### "Ready for review" checklist

- [x] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [n/a] ~If needed, `CHANGELOG.md` updated~ (this is a CI/infrastructure change only; not user-facing or package functionality)
- [n/a] ~If needed, docs and/or `README.md` updated~ (this is a CI/infrastructure change only; not user-facing or package functionality)
- [n/a] If needed, unit tests added *(unsure how? see below!)*
- [x] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [x] At least one approval

> **Need help?** We welcome contributions at every experience level. You don't have to
> write tests alone — open your PR and ask for help. It's also fine to let GitHub run tests
> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
> instead of running them locally. If anything fails and you're not sure why, just
> mention `@earthaccess-dev/maintainers` in a comment and we'll work with you!


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1443.org.readthedocs.build/en/1443/

<!-- readthedocs-preview earthaccess end -->