### PR TITLE
Fixes incorrect granule counts in certain cases

### DIFF
--- a/earthaccess/utils/_search.py
+++ b/earthaccess/utils/_search.py
@@ -48,6 +48,6 @@ def get_results(
 
         results.extend(latest)
 
-        more_results = page_size <= len(latest) and len(results) < limit
+        more_results = len(latest) > 0 and len(results) < limit
 
     return results

--- a/tests/unit/fixtures/vcr_cassettes/TestResults.test_get_all_less_than_2k.yaml
+++ b/tests/unit/fixtures/vcr_cassettes/TestResults.test_get_all_less_than_2k.yaml
@@ -2092,4 +2092,43 @@ interactions:
       status:
         code: 200
         message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        cmr-search-after:
+          - '["pocloud",1495497600000,2658328520]'
+      method: GET
+      uri: https://cmr.earthdata.nasa.gov/search/granules.umm_json?short_name=TELLUS_GRAC_L3_JPL_RL06_LND_v04&page_size=2000
+    response:
+      body:
+        string: '{"hits":163,"took":1,"items":[]}'
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        CMR-Hits:
+          - "163"
+        CMR-Request-Id:
+          - 00000000-0000-0000-0000-000000000000
+        CMR-Took:
+          - "1"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/vnd.nasa.cmr.umm_results+json;version=1.6.5; charset=utf-8
+        Server:
+          - ServerTokens ProductOnly
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+      status:
+        code: 200
+        message: OK
+
 version: 1

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -6,7 +6,8 @@ import os.path
 import earthaccess
 import responses
 from earthaccess.results import DataCollection, DataGranule
-from earthaccess.search import DataCollections
+from earthaccess.search import DataCollections, DataGranules
+from earthaccess.utils._search import get_results
 from vcr.unittest import VCRTestCase  # type: ignore[import-untyped]
 
 logging.basicConfig()
@@ -165,8 +166,9 @@ class TestResults(VCRTestCase):
             count=2000,
         )
 
-        # Assert that we performed a hits query and one search results query
-        self.assertEqual(len(self.cassette), 2)
+        # Assert that we performed a hits query, a results query, and a final
+        # query that returns an empty page (to detect the end of the results).
+        self.assertEqual(len(self.cassette), 3)
         self.assertEqual(len(granules), 163)
         self.assertTrue(unique_results(granules))
 
@@ -180,8 +182,9 @@ class TestResults(VCRTestCase):
             count=3000,
         )
 
-        # Assert that we performed a hits query and two search results queries
-        self.assertEqual(len(self.cassette), 3)
+        # Assert that we performed a hits query, two results queries, and a
+        # final query that returns an empty page.
+        self.assertEqual(len(self.cassette), 4)
         self.assertEqual(
             len(granules),
             int(self.cassette.responses[0]["headers"]["CMR-Hits"][0]),
@@ -191,6 +194,63 @@ class TestResults(VCRTestCase):
             min(3000, int(self.cassette.responses[0]["headers"]["CMR-Hits"][0])),
         )
         self.assertTrue(unique_results(granules))
+
+    @responses.activate
+    def test_get_paginates_past_short_first_page(self):
+        """A page shorter than the requested page_size must not end pagination.
+
+        Regression test: for some searches CMR returns fewer than `page_size`
+        items on a page even though more results remain (e.g. the granule search
+        for C3974616058-LPCLOUD over 2024 returns 1985 items on the first page
+        of 2000). The old code stopped paginating after such a short page,
+        silently dropping the rest of the results.
+        """
+        url = "https://cmr.earthdata.nasa.gov/search/granules.umm_json"
+
+        # First page is short (fewer than the requested page_size), but CMR
+        # still signals more results via the CMR-Search-After header.
+        responses.add(
+            responses.GET,
+            url,
+            json={
+                "hits": 12070,
+                "items": [
+                    {"meta": {"concept-id": f"G{i}-LPCLOUD"}, "umm": {}}
+                    for i in range(1985)
+                ],
+            },
+            headers={"CMR-Search-After": '["lpcloud",1718999394000,4165185217]'},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            json={
+                "hits": 12070,
+                "items": [
+                    {"meta": {"concept-id": f"G{i}-LPCLOUD"}, "umm": {}}
+                    for i in range(1985, 3985)
+                ],
+            },
+            headers={"CMR-Search-After": '["lpcloud",1722041241000,4166963562]'},
+            status=200,
+        )
+        # Final request: empty page, no CMR-Search-After header.
+        responses.add(
+            responses.GET,
+            url,
+            json={"hits": 12070, "items": []},
+            status=200,
+        )
+
+        query = DataGranules()
+        query.concept_id("C3974616058-LPCLOUD")
+        query.temporal("2024-01-01", "2024-12-31")
+
+        results = get_results(query.session, query, limit=12070)
+
+        self.assertEqual(len(results), 3985)
+        self.assertEqual(len(responses.calls), 3)
 
     def test_collections_less_than_2k(self):
         """If we execute a get_all then we expect multiple


### PR DESCRIPTION
<!--
IMPORTANT: Please open your PR in draft mode. Only mark it "Ready for review" after
completing the "Ready for review" checklist.

If you read the guide and your question isn't answered, please ping `@earthaccess-dev/maintainers` in a comment!
--->

## Description

When searching with the earthaccess for a dataset with the "temporal" parameter (see below), it returns fewer granules (1,985 in this case of GEDI L1B dataset). The same dataset in the [Earthdata search](https://search.earthdata.nasa.gov/search/granules?p=C3974616058-LPCLOUD&pg[0][v]=f&pg[0][qt]=2024-01-01T00%3A00%3A00.000Z%2C2024-12-31T23%3A59%3A59.999Z&pg[0][gsk]=-start_date&q=gedi%20l1b) and [CMR API,](https://cmr.earthdata.nasa.gov/search/granules?concept_id=C3974616058-LPCLOUD&temporal=2024-01-01T00:00:00Z,2024-12-31T23:59:59Z) shows 12,070 granules. This PR fixes this discrepancy in the granule count.

<img width="405" height="142" alt="image" src="https://github.com/user-attachments/assets/74a25392-a224-4770-9dc0-fdcf4d714d1b" />

Fixes #1445

---

#### "Ready for review" checklist

- [ ] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [ ] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/)
- [ ] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [X] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [ ] If needed, `CHANGELOG.md` updated
- [ ] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval

> **Need help?** We welcome contributions at every experience level. You don't have to
> write tests alone — open your PR and ask for help. It's also fine to let GitHub run tests
> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
> instead of running them locally. If anything fails and you're not sure why, just
> mention `@earthaccess-dev/maintainers` in a comment and we'll work with you!


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1444.org.readthedocs.build/en/1444/

<!-- readthedocs-preview earthaccess end -->