### PR TITLE
Releasing v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.19.0] - 2026-09-03
+
 ### Breaking changes
 
 - Many `DataCollection` and `DataGranule` methods are now read-only fields.
@@ -736,4 +738,5 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 [v0.16.0]: https://github.com/earthaccess-dev/earthaccess/releases/tag/v0.16.0
 [v0.17.0]: https://github.com/earthaccess-dev/earthaccess/compare/v0.16.0...v0.17.0
 [v0.18.0]: https://github.com/earthaccess-dev/earthaccess/compare/v0.17.0...v0.18.0
-[Unreleased]: https://github.com/earthaccess-dev/earthaccess/compare/v0.18.0...HEAD
+[v0.19.0]: https://github.com/earthaccess-dev/earthaccess/compare/v0.18.0...v0.19.0
+[Unreleased]: https://github.com/earthaccess-dev/earthaccess/compare/v0.19.0...HEAD

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ keywords:
 url: "https://earthaccess.readthedocs.io"
 repository-code: "https://github.com/earthaccess-dev/earthaccess"
 
-version: "0.18.0"
-date-released: "2026-05-12"
+version: "0.19.0"
+date-released: "2026-09-03"
 
 authors:
   - family-names: "Barrett"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,7 @@ combine-as-imports = true
 convention = "google"
 
 [tool.bumpversion]
-current_version = "0.18.0"
+current_version = "0.19.0"
 commit = false
 tag = true
 allow_dirty = false


### PR DESCRIPTION
<!--
IMPORTANT: Please open your PR in draft mode. Only mark it "Ready for review" after
completing the "Ready for review" checklist.

If you read the guide and your question isn't answered, please ping `@earthaccess-dev/maintainers` in a comment!
--->

## Description

<!--
Replace this text, including the symbols above and below it, with descriptive text about
the change you are proposing. Please include a reference to any issues addressed or
resolved in that text, for example "resolves #1".
-->


---

#### AI usage disclosure

Using AI tools is welcome. Per our [AI Policy](https://earthaccess.readthedocs.io/en/latest/contributor/ai-policy/),
we just ask that you disclose any use of generative AI tools in this contribution.

- [x] I have disclosed AI tool usage below, or confirmed that no AI tools were used

<!--
If you used AI tools, note which tool(s) and version(s) were used, how they were used, and which
parts of this contribution are AI-generated.
-->

#### "Ready for review" checklist

- [x] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added *(unsure how? see below!)*
- [x] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval

> **Need help?** We welcome contributions at every experience level. You don't have to
> write tests alone — open your PR and ask for help. It's also fine to let GitHub run tests
> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
> instead of running them locally. If anything fails and you're not sure why, just
> mention `@earthaccess-dev/maintainers` in a comment and we'll work with you!


## V0.19.0 

Preparing to release `v0.19.0`  these are the release notes, I'll look for maybe one or two more easy PRs to merge today and then release it. 

## What's Changed

### 💥 Breaking Changes

* [**Migration guide**](https://earthaccess.readthedocs.io/en/stable/user/backwards-compatibility/#migration-guides)
* Migrate many methods to properties. Several methods are now accessed as properties rather than called as methods. #1428 (@mfisher87) and (@andypbarrett)
 

### 🚀 Enhancements
* Add support for Python 3.14. #1446 (@danielfromearth)
* Improve DataServices URL handling by using the configured CMR base URL from the authentication service. #1343 (@mvanhorn)
* Improve S3 URL generation by deriving each S3 link from its corresponding HTTPS link. #1373 (@arpitjain099)
* Document OPeNDAP URL retrieval for direct access to OPeNDAP resources. #1448 (@svsam)

### 🐛 Bug Fixes
* Fix incorrect granule counts in certain search result cases. #1444 (@rupesh2)
* Fix unit test failures introduced by a new release of aiohttp. #1367 (@mfisher87)
* Fix a deprecation warning. #1420 (@andypbarrett)

