### PR TITLE
Rename  Query Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Renamed the query classes `DataCollections`, `DataGranules`, and
+  `DataServices` to `DataCollectionsQuery`, `DataGranulesQuery`, and
+  `DataServicesQuery`.
+  ([#1363](https://github.com/earthaccess-dev/earthaccess/issues/1363))
+  ([@Sherwin-14](https://github.com/Sherwin-14))
+
 ## [v0.19.0] - 2026-09-03
 
 ### Breaking changes

--- a/docs/api/collections/collections-query.md
+++ b/docs/api/collections/collections-query.md
@@ -1,8 +1,8 @@
-# Documentation for `DataCollections`
+# Documentation for `DataCollectionsQuery`
 
-### DataCollections is the class `earthaccess` uses to query CMR at the **dataset** level.
+### DataCollectionsQuery is the class `earthaccess` uses to query CMR at the **dataset** level.
 
-::: earthaccess.search.DataCollections
+::: earthaccess.search.DataCollectionsQuery
     options:
         show_source: false
         inherited_members: true

--- a/docs/api/collections/collections-services.md
+++ b/docs/api/collections/collections-services.md
@@ -1,6 +1,6 @@
 # Documentation for `Collection Services`
 
-::: earthaccess.DataServices
+::: earthaccess.DataServicesQuery
     options:
       inherited_members: true
     show_root_heading: true

--- a/docs/api/granules/granules-query.md
+++ b/docs/api/granules/granules-query.md
@@ -1,9 +1,9 @@
 # Documentation for `Granules`
 
 
-### DataGranules is the class `earthaccess` uses to query CMR at the **granule** level.
+### DataGranulesQuery is the class `earthaccess` uses to query CMR at the **granule** level.
 
-::: earthaccess.search.DataGranules
+::: earthaccess.search.DataGranulesQuery
     options:
       inherited_members: true
     show_root_heading: true

--- a/docs/user/tutorials/restricted-datasets.ipynb
+++ b/docs/user/tutorials/restricted-datasets.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from earthaccess import Auth, DataCollections, DataGranules, Store\n",
+    "from earthaccess import Auth, DataCollectionsQuery, DataGranulesQuery, Store\n",
     "\n",
     "auth = Auth()"
    ]
@@ -83,19 +83,19 @@
     "\n",
     "```python\n",
     "# An anonymous query to CMR\n",
-    "Query = DataCollections().keyword('elevation')\n",
+    "Query = DataCollectionsQuery().keyword('elevation')\n",
     "# An authenticated query to CMR\n",
-    "Query = DataCollections(auth).keyword('elevation')\n",
+    "Query = DataCollectionsQuery(auth).keyword('elevation')\n",
     "```\n",
     "\n",
-    "and it's the same with DataGranules\n",
+    "and it's the same with DataGranulesQuery\n",
     "\n",
     "\n",
     "```python\n",
     "# An anonymous query to CMR\n",
-    "Query = DataGranules().keyword('elevation')\n",
+    "Query = DataGranulesQuery().keyword('elevation')\n",
     "# An authenticated query to CMR\n",
-    "Query = DataGranules(auth).keyword('elevation')\n",
+    "Query = DataGranulesQuery(auth).keyword('elevation')\n",
     "```\n",
     "\n",
     "\n",
@@ -109,8 +109,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The first step is to create a DataCollections query\n",
-    "Query = DataCollections()\n",
+    "# The first step is to create a DataCollectionsQuery query\n",
+    "Query = DataCollectionsQuery()\n",
     "\n",
     "# Use chain methods to customize our query\n",
     "Query.short_name(\"ATL06\").version(\"006\")\n",
@@ -142,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Query = DataCollections(auth)\n",
+    "Query = DataCollectionsQuery(auth)\n",
     "\n",
     "# Use chain methods to customize our query\n",
     "Query.short_name(\"ATL06\").version(\"006\")\n",
@@ -166,7 +166,7 @@
     "#### Interpreting the results\n",
     "\n",
     "The `hits()` method above will tell you the number of query hits, but only for publicly available data sets.\n",
-    "In this case because cloud hosted ICESat-2 data are not yet publicly available, CMR will return “1” hits, if you filtered DataCollections by provider = NSIDC_CPRD you'll get `0` hits. For now we need an alternative method of seeing how many cloud data sets are available at NSIDC. This is only temporary until cloud-hosted ICESat-2 become publicly available. We can create a collections object (we’re going to want one of these soon anyhow) and print the len() of the collections object to see the true number of hits. \n",
+    "In this case because cloud hosted ICESat-2 data are not yet publicly available, CMR will return “1” hits, if you filtered DataCollectionsQuery by provider = NSIDC_CPRD you'll get `0` hits. For now we need an alternative method of seeing how many cloud data sets are available at NSIDC. This is only temporary until cloud-hosted ICESat-2 become publicly available. We can create a collections object (we’re going to want one of these soon anyhow) and print the len() of the collections object to see the true number of hits. \n",
     "\n",
     "> **Note**: Since we cannot rely on `hits()` we need to be aware that `get()` may get us too many metadata records depending on the dataset and how broad our query is.\n"
    ]
@@ -179,7 +179,7 @@
    "outputs": [],
    "source": [
     "Query = (\n",
-    "    DataGranules(auth)\n",
+    "    DataGranulesQuery(auth)\n",
     "    .concept_id(\"C2153572614-NSIDC_CPRD\")\n",
     "    .bounding_box(-134.7, 58.9, -133.9, 59.2)\n",
     "    .temporal(\"2020-03-01\", \"2020-03-30\")\n",

--- a/earthaccess/__init__.py
+++ b/earthaccess/__init__.py
@@ -20,8 +20,8 @@ from .api import (
     status,
 )
 from .auth import Auth
-from .search import DataCollection, DataCollections, DataGranule, DataGranules
-from .services import DataServices
+from .search import DataCollection, DataCollectionsQuery, DataGranule, DataGranulesQuery
+from .services import DataServicesQuery
 from .store import Store
 from .system import PROD, UAT
 from .virtual import virtualize
@@ -36,10 +36,10 @@ __all__ = [
     "Auth",
     # search.py
     "DataCollection",
-    "DataCollections",
+    "DataCollectionsQuery",
     "DataGranule",
-    "DataGranules",
-    "DataServices",
+    "DataGranulesQuery",
+    "DataServicesQuery",
     # store.py
     "Store",
     # api.py

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -13,11 +13,11 @@ from typing_extensions import (
 
 import earthaccess
 from earthaccess.exceptions import LoginStrategyUnavailable, ServiceOutage
-from earthaccess.services import DataServices
+from earthaccess.services import DataServicesQuery
 
 from .auth import Auth
 from .results import DataCollection, DataGranule
-from .search import CollectionQuery, DataCollections, DataGranules, GranuleQuery
+from .search import CollectionQuery, DataCollectionsQuery, DataGranulesQuery, GranuleQuery
 from .store import Store
 from .system import PROD, System
 from .utils import _validation as validate
@@ -176,9 +176,9 @@ def search_datasets(count: int = -1, **kwargs: Any) -> list[DataCollection]:
         )
         return []
     if earthaccess.__auth__.authenticated:
-        query = DataCollections(auth=earthaccess.__auth__).parameters(**kwargs)
+        query = DataCollectionsQuery(auth=earthaccess.__auth__).parameters(**kwargs)
     else:
-        query = DataCollections().parameters(**kwargs)
+        query = DataCollectionsQuery().parameters(**kwargs)
     datasets_found = query.hits()
     logger.info("Datasets found: %s", datasets_found)
     if count > 0:
@@ -270,9 +270,9 @@ def search_data(count: int = -1, **kwargs: Any) -> list[DataGranule]:
         ```
     """
     if earthaccess.__auth__.authenticated:
-        query = DataGranules(earthaccess.__auth__).parameters(**kwargs)
+        query = DataGranulesQuery(earthaccess.__auth__).parameters(**kwargs)
     else:
-        query = DataGranules().parameters(**kwargs)
+        query = DataGranulesQuery().parameters(**kwargs)
     granules_found = query.hits()
     logger.info("Granules found: %s", granules_found)
     if count > 0:
@@ -301,7 +301,7 @@ def search_services(count: int = -1, **kwargs: Any) -> list[Any]:
         services = search_services(provider="POCLOUD", keyword="COG")
         ```
     """
-    query = DataServices(auth=earthaccess.__auth__).parameters(**kwargs)
+    query = DataServicesQuery(auth=earthaccess.__auth__).parameters(**kwargs)
     hits = query.hits()
     logger.info("Services found: %s", hits)
 
@@ -515,9 +515,9 @@ def collection_query() -> CollectionQuery:
         a query builder instance for data collections.
     """
     if earthaccess.__auth__.authenticated:
-        query_builder = DataCollections(earthaccess.__auth__)
+        query_builder = DataCollectionsQuery(earthaccess.__auth__)
     else:
-        query_builder = DataCollections()
+        query_builder = DataCollectionsQuery()
     return query_builder
 
 
@@ -528,9 +528,9 @@ def granule_query() -> GranuleQuery:
         a query builder instance for data granules.
     """
     if earthaccess.__auth__.authenticated:
-        query_builder = DataGranules(earthaccess.__auth__)
+        query_builder = DataGranulesQuery(earthaccess.__auth__)
     else:
-        query_builder = DataGranules()
+        query_builder = DataGranulesQuery()
     return query_builder
 
 

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -17,7 +17,12 @@ from earthaccess.services import DataServicesQuery
 
 from .auth import Auth
 from .results import DataCollection, DataGranule
-from .search import CollectionQuery, DataCollectionsQuery, DataGranulesQuery, GranuleQuery
+from .search import (
+    CollectionQuery,
+    DataCollectionsQuery,
+    DataGranulesQuery,
+    GranuleQuery,
+)
 from .store import Store
 from .system import PROD, System
 from .utils import _validation as validate

--- a/earthaccess/results.py
+++ b/earthaccess/results.py
@@ -8,7 +8,7 @@ import requests
 import earthaccess
 
 from .formatters import _repr_granule_html
-from .services import DataServices
+from .services import DataServicesQuery
 
 
 @cache
@@ -226,7 +226,7 @@ class DataCollection(CustomDict):
         """Return list of services available for this collection."""
         services = self.get("meta", {}).get("associations", {}).get("services", [])
         queries = (
-            DataServices(auth=earthaccess.__auth__).parameters(concept_id=service)
+            DataServicesQuery(auth=earthaccess.__auth__).parameters(concept_id=service)
             for service in services
         )
 

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -24,11 +24,11 @@ type FloatLike = str | SupportsFloat
 type PointLike = tuple[FloatLike, FloatLike]
 
 
-class DataCollections(CollectionQuery):
+class DataCollectionsQuery(CollectionQuery):
     """Query CMR for collection metadata.
 
     ???+ Info
-        The DataCollection class queries against
+        The DataCollectionsQuery class queries against
         https://cmr.earthdata.nasa.gov/search/collections.umm_json,
         the response has to be in umm_json to use the result classes.
     """
@@ -37,7 +37,7 @@ class DataCollections(CollectionQuery):
     _format = "umm_json"
 
     def __init__(self, auth: Auth | None = None, *args: Any, **kwargs: Any) -> None:
-        """Builds an instance of DataCollections to query the CMR.
+        """Builds an instance of DataCollectionsQuery to query the CMR.
 
         Parameters:
             auth: An authenticated `Auth` instance. This is an optional parameter
@@ -223,7 +223,7 @@ class DataCollections(CollectionQuery):
 
         ???+ Example
             ```python
-            query = DataCollections.parameters(
+            query = DataCollectionsQuery.parameters(
                 short_name="AST_L1T",
                 temporal=("2015-01","2015-02"),
                 point=(42.5, -101.25)
@@ -418,7 +418,7 @@ class DataCollections(CollectionQuery):
         return super().temporal(date_from, date_to, exclude_boundary)
 
 
-class DataGranules(GranuleQuery):
+class DataGranulesQuery(GranuleQuery):
     """A Granule oriented client for NASA CMR.
 
     API: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html
@@ -481,7 +481,7 @@ class DataGranules(GranuleQuery):
             limit: The number of results to return.
 
         Returns:
-            Query results as a (possibly empty) list of `DataGranules` instances.
+            Query results as a (possibly empty) list of `DataGranule` instances.
 
         Raises:
             RuntimeError: The CMR query failed.
@@ -499,7 +499,7 @@ class DataGranules(GranuleQuery):
 
         ???+ Example
             ```python
-            query = DataCollections.parameters(
+            query = DataCollectionsQuery.parameters(
                 short_name="AST_L1T",
                 temporal=("2015-01","2015-02"),
                 point=(42.5, -101.25)
@@ -945,7 +945,7 @@ class DataGranules(GranuleQuery):
             RuntimeError: The CMR query to get the collection for the DOI fails.
         """
         # TODO consider deferring this query until the search is executed
-        collection = DataCollections().doi(doi).get()
+        collection = DataCollectionsQuery().doi(doi).get()
 
         # TODO consider raising an exception when there are multiple collections, since
         # we can't know which one the user wants, and choosing one is arbitrary.

--- a/earthaccess/services.py
+++ b/earthaccess/services.py
@@ -8,7 +8,7 @@ from .auth import Auth
 from .utils import _search as search
 
 
-class DataServices(ServiceQuery):
+class DataServicesQuery(ServiceQuery):
     """A Service client for NASA CMR that returns data on collection services.
 
     API: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#service
@@ -17,7 +17,7 @@ class DataServices(ServiceQuery):
     _format = "umm_json"
 
     def __init__(self, auth: Auth | None = None, *args: Any, **kwargs: Any) -> None:
-        """Build an instance of DataService to query CMR.
+        """Build an instance of DataServicesQuery to query CMR.
 
         auth is an optional parameter for queries that need authentication,
         e.g. restricted datasets.

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -32,7 +32,7 @@ from .auth import Auth
 from .daac import DAAC_TEST_URLS, find_provider
 from .exceptions import DownloadFailure, EulaNotAccepted
 from .results import DataGranule
-from .search import DataCollections
+from .search import DataCollectionsQuery
 
 logger = logging.getLogger(__name__)
 
@@ -274,7 +274,7 @@ class Store:
         return find_provider(daac, True)  # noqa: FBT003
 
     def _is_cloud_collection(self, concept_id: list[str]) -> bool:
-        collection = DataCollections(self.auth).concept_id(concept_id).get()
+        collection = DataCollectionsQuery(self.auth).concept_id(concept_id).get()
         return len(collection) > 0 and "s3-links" in collection[0]["meta"]
 
     def _own_s3_credentials(self, links: list[dict[str, Any]]) -> str | None:

--- a/tests/integration/test_cloud_download.py
+++ b/tests/integration/test_cloud_download.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import earthaccess
 import pytest
-from earthaccess import Auth, DataGranules, Store
+from earthaccess import Auth, DataGranulesQuery, Store
 
 from .param import ProviderParam
 from .sample import get_sample_granules, top_collections_for_provider
@@ -77,7 +77,7 @@ def test_earthaccess_can_download_cloud_collection_granules(tmp_path, daac):
     logger.info("On-premises collections for %s: %s", provider, len(top_collections))
 
     for concept_id in top_collections:
-        granule_query = DataGranules().concept_id(concept_id)
+        granule_query = DataGranulesQuery().concept_id(concept_id)
         total_granules = granule_query.hits()
         granules = granule_query.get(granules_count)
 

--- a/tests/integration/test_cloud_open.py
+++ b/tests/integration/test_cloud_open.py
@@ -3,7 +3,7 @@ import logging
 import earthaccess
 import magic
 import pytest
-from earthaccess import Auth, DataGranules, Store
+from earthaccess import Auth, DataGranulesQuery, Store
 
 from .param import ProviderParam
 from .sample import get_sample_granules, top_collections_for_provider
@@ -71,7 +71,7 @@ def test_earthaccess_can_open_onprem_collection_granules(daac):
     logger.info("On-premises collections for %s: %s", provider, len(top_collections))
 
     for concept_id in top_collections:
-        granule_query = DataGranules().concept_id(concept_id)
+        granule_query = DataGranulesQuery().concept_id(concept_id)
         total_granules = granule_query.hits()
         granules = granule_query.get(granules_count)
         assert len(granules) > 0, "Could not fetch granules"

--- a/tests/unit/test_collection_queries.py
+++ b/tests/unit/test_collection_queries.py
@@ -2,7 +2,7 @@
 import datetime as dt
 
 import pytest
-from earthaccess.search import DataCollections
+from earthaccess.search import DataCollectionsQuery
 
 valid_single_dates = [
     ("2001-12-12", "2001-12-21", "2001-12-12T00:00:00Z,2001-12-21T23:59:59Z"),
@@ -33,50 +33,50 @@ invalid_single_dates = [
 
 
 def test_no_default_params():
-    query = DataCollections()
+    query = DataCollectionsQuery()
     assert len(query.params) == 0
 
 
 def test_query_can_find_cloud_provider():
-    query = DataCollections().daac("PODAAC").cloud_hosted(True)
+    query = DataCollectionsQuery().daac("PODAAC").cloud_hosted(True)
     assert query.params["provider"] == "POCLOUD"
-    query = DataCollections().cloud_hosted(True).daac("PODAAC")
+    query = DataCollectionsQuery().cloud_hosted(True).daac("PODAAC")
     assert query.params["provider"] == "POCLOUD"
     # SEDAC does not have a cloud provider, so it should default to the on prem provider
-    query = DataCollections().cloud_hosted(True).daac("SEDAC")
+    query = DataCollectionsQuery().cloud_hosted(True).daac("SEDAC")
     assert query.params["provider"] == "ESDIS"
-    query = DataCollections().daac("ASDC").cloud_hosted(True)
+    query = DataCollectionsQuery().daac("ASDC").cloud_hosted(True)
     assert query.params["provider"] == "LARC_CLOUD"
-    query = DataCollections().cloud_hosted(True).daac("ASDC")
+    query = DataCollectionsQuery().cloud_hosted(True).daac("ASDC")
     assert query.params["provider"] == "LARC_CLOUD"
 
 
 def test_querybuilder_can_handle_doi():
     doi = "10.5067/AQR50-3Q7CS"
-    query = DataCollections().doi(doi)
+    query = DataCollectionsQuery().doi(doi)
     assert query.params["doi"] == doi
-    query = DataCollections().cloud_hosted(True).daac("PODAAC").doi(doi)
+    query = DataCollectionsQuery().cloud_hosted(True).daac("PODAAC").doi(doi)
     assert query.params["doi"] == doi
 
 
 def test_querybuilder_can_handle_has_granules():
-    query = DataCollections().has_granules(False)
+    query = DataCollectionsQuery().has_granules(False)
     assert not query.params["has_granules"]
-    query = DataCollections().has_granules(True)
+    query = DataCollectionsQuery().has_granules(True)
     assert query.params["has_granules"]
-    query = DataCollections().has_granules(None)
+    query = DataCollectionsQuery().has_granules(None)
     assert "has_granules" not in query.params
 
 
 @pytest.mark.parametrize("start,end,expected", valid_single_dates)
 def test_query_can_parse_single_dates(start, end, expected):
-    query = DataCollections().temporal(start, end)
+    query = DataCollectionsQuery().temporal(start, end)
     assert query.params["temporal"][0] == expected
 
 
 @pytest.mark.parametrize("start,end,expected", invalid_single_dates)
 def test_query_can_handle_invalid_dates(start, end, expected):  # noqa: ARG001
-    query = DataCollections()
+    query = DataCollectionsQuery()
     assert "temporal" not in query.params
     with pytest.raises(ValueError):
         query.temporal(start, end)

--- a/tests/unit/test_granule_queries.py
+++ b/tests/unit/test_granule_queries.py
@@ -2,7 +2,7 @@
 import datetime as dt
 
 import pytest
-from earthaccess.search import DataGranules
+from earthaccess.search import DataGranulesQuery
 
 valid_single_dates = [
     ("2001-12-12", "2001-12-21", "2001-12-12T00:00:00Z,2001-12-21T23:59:59Z"),
@@ -41,13 +41,13 @@ bbox_queries = [
 
 @pytest.mark.parametrize("start,end,expected", valid_single_dates)
 def test_query_can_parse_single_dates(start, end, expected):
-    granules = DataGranules().short_name("MODIS").temporal(start, end)
+    granules = DataGranulesQuery().short_name("MODIS").temporal(start, end)
     assert granules.params["temporal"][0] == expected
 
 
 @pytest.mark.parametrize("start,end,expected", invalid_single_dates)
 def test_query_can_handle_invalid_dates(start, end, expected):  # noqa: ARG001
-    granules = DataGranules().short_name("MODIS")
+    granules = DataGranulesQuery().short_name("MODIS")
     assert "temporal" not in granules.params
     with pytest.raises(ValueError):
         granules.temporal(start, end)
@@ -55,5 +55,5 @@ def test_query_can_handle_invalid_dates(start, end, expected):  # noqa: ARG001
 
 @pytest.mark.parametrize("bbox,expected", bbox_queries)
 def test_query_handles_bbox(bbox, expected):
-    granules = DataGranules().short_name("MODIS").bounding_box(*bbox)
+    granules = DataGranulesQuery().short_name("MODIS").bounding_box(*bbox)
     assert ("bounding_box" in granules.params) == expected

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -6,7 +6,7 @@ import os.path
 import earthaccess
 import responses
 from earthaccess.results import DataCollection, DataGranule
-from earthaccess.search import DataCollections, DataGranules
+from earthaccess.search import DataCollectionsQuery, DataGranulesQuery
 from earthaccess.utils._search import get_results
 from vcr.unittest import VCRTestCase  # type: ignore[import-untyped]
 
@@ -243,7 +243,7 @@ class TestResults(VCRTestCase):
             status=200,
         )
 
-        query = DataGranules()
+        query = DataGranulesQuery()
         query.concept_id("C3974616058-LPCLOUD")
         query.temporal("2024-01-01", "2024-12-31")
 
@@ -257,7 +257,7 @@ class TestResults(VCRTestCase):
         invocations of a cmr granule search and
         to not fetch back more results than we ask for.
         """
-        query = DataCollections().daac("PODAAC").cloud_hosted(True)
+        query = DataCollectionsQuery().daac("PODAAC").cloud_hosted(True)
         collections = query.get(20)
 
         # Assert that we performed a single search results query
@@ -271,7 +271,7 @@ class TestResults(VCRTestCase):
         invocations of a cmr granule search and
         to not fetch back more results than we ask for.
         """
-        query = DataCollections()
+        query = DataCollectionsQuery()
         collections = query.get(3000)
 
         # Assert that we performed two search results queries


### PR DESCRIPTION

## Description

Renamed the query classes so they don't read like results anymore. This one is a clean rename. Resolves #1363.

---

#### AI usage disclosure

Using AI tools is welcome. Per our [AI Policy](https://earthaccess.readthedocs.io/en/latest/contributor/ai-policy/),
we just ask that you disclose any use of generative AI tools in this contribution.

- [x] I have disclosed AI tool usage below, or confirmed that no AI tools were used

<!--
If you used AI tools, note which tool(s) and version(s) were used, how they were used, and which
parts of this contribution are AI-generated.
-->

#### "Ready for review" checklist

- [ ] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x] Please review our [Pull Request Guide](https://earthaccess.readthedocs.io/en/latest/contributor/howto/pr-guide/)
- [x] Mark "ready for review" after following instructions in the guide

#### Merge checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [ ] If needed, unit tests added *(unsure how? see below!)*
- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval

> **Need help?** We welcome contributions at every experience level. You don't have to
> write tests alone — open your PR and ask for help. It's also fine to let GitHub run tests
> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
> instead of running them locally. If anything fails and you're not sure why, just
> mention `@earthaccess-dev/maintainers` in a comment and we'll work with you!


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1465.org.readthedocs.build/en/1465/

<!-- readthedocs-preview earthaccess end -->